### PR TITLE
Changing http method "POST" to "PUT" in TeamsAPI

### DIFF
--- a/ciscosparkapi/api/teams.py
+++ b/ciscosparkapi/api/teams.py
@@ -190,7 +190,7 @@ class TeamsAPI(object):
                             "argument must be specified."
             raise ciscosparkapiException(error_message)
         # API request
-        json_obj = self._session.post('teams/' + teamId,
+        json_obj = self._session.put('teams/' + teamId,
                                       json=update_attributes)
         # Return a Team object created from the response JSON data
         return Team(json_obj)


### PR DESCRIPTION
Modifying "update" function's http method to "PUT" which was "POST" earlier due to which update team was returning error