### PR TITLE
Automatic Rate-Limit Handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,8 +36,11 @@ toxtest : local/environment.sh tox.ini
 
 .PHONY : pytest
 pytest : local/environment.sh
-	source local/environment.sh
-	pytest
+	source local/environment.sh && pytest -m "not ratelimit"
+
+.PHONY : pytest-rate-limit
+pytest-rate-limit : local/environment.sh
+	source local/environment.sh && pytest -m "ratelimit"
 
 .PHONY : lint
 lint :

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ tests: toxtest lint ;
 
 .PHONY : ci
 ci :
-	pytest
+	pytest -m "not ratelimit"
 
 .PHONY : toxtest
 toxtest : local/environment.sh tox.ini

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,7 @@ clean : cleanbuild cleandocs cleanpytest cleantox ;
 .PHONY : cleanbuild
 cleanbuild :
 	rm -rf ./ciscosparkapi.egg-info/
+	rm -rf ./__pycache__/
 
 .PHONY : cleandocs
 cleandocs :

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,12 @@ ciscosparkapi
 
 *Simple, lightweight, scalable Python API wrapper for the Cisco Spark APIs*
 
+.. image:: https://img.shields.io/badge/license-MIT-blue.svg
+    :target: https://github.com/CiscoDevNet/ciscosparkapi/blob/master/LICENSE
 .. image:: https://img.shields.io/pypi/v/ciscosparkapi.svg
     :target: https://pypi.python.org/pypi/ciscosparkapi
+.. image:: https://travis-ci.org/CiscoDevNet/ciscosparkapi.svg?branch=master
+    :target: https://travis-ci.org/CiscoDevNet/ciscosparkapi
 .. image:: https://readthedocs.org/projects/ciscosparkapi/badge/?version=latest
     :target: http://ciscosparkapi.readthedocs.io/en/latest/?badge=latest
 
@@ -73,6 +77,8 @@ ciscosparkapi does all of this for you...
   + Returned Data Objects ==> Native Python objects
 
 + **Automatic and transparent pagination!**
+
++ **Automatic rate-limit handling!** *(wait|retry)*
 
 + Multipart encoding and uploading of local files
 

--- a/ciscosparkapi/__init__.py
+++ b/ciscosparkapi/__init__.py
@@ -147,11 +147,11 @@ class CiscoSparkAPI(object):
         # leverage a single RESTful 'session' connecting to the Cisco Spark
         # cloud.
         self._session = RestSession(
-                access_token,
-                base_url,
-                timeout=timeout,
-                single_request_timeout=single_request_timeout,
-                rate_limit_timeout=rate_limit_timeout,
+            access_token,
+            base_url,
+            timeout=timeout,
+            single_request_timeout=single_request_timeout,
+            rate_limit_timeout=rate_limit_timeout,
         )
 
         # Spark API wrappers

--- a/ciscosparkapi/__init__.py
+++ b/ciscosparkapi/__init__.py
@@ -12,6 +12,7 @@ from __future__ import (
 from builtins import *
 from past.builtins import basestring
 
+import logging
 import os
 
 from ciscosparkapi.exceptions import ciscosparkapiException, SparkApiError
@@ -49,6 +50,12 @@ DEFAULT_TIMEOUT = 60
 ACCESS_TOKEN_ENVIRONMENT_VARIABLE = 'SPARK_ACCESS_TOKEN'
 
 
+# Initialize Package Logging
+logger = logging.getLogger(__name__)
+logger.addHandler(logging.NullHandler())
+
+
+# Main Package Interface
 class CiscoSparkAPI(object):
     """Cisco Spark API wrapper.
 

--- a/ciscosparkapi/__init__.py
+++ b/ciscosparkapi/__init__.py
@@ -18,7 +18,7 @@ import os
 from ciscosparkapi.exceptions import ciscosparkapiException, SparkApiError
 from ciscosparkapi.restsession import (
     DEFAULT_SINGLE_REQUEST_TIMEOUT,
-    DEFAULT_RATE_LIMIT_TIMEOUT,
+    DEFAULT_WAIT_ON_RATE_LIMIT,
     RestSession,
 )
 from ciscosparkapi.api.people import Person, PeopleAPI
@@ -97,7 +97,7 @@ class CiscoSparkAPI(object):
     def __init__(self, access_token=None, base_url=DEFAULT_BASE_URL,
                  timeout=None,
                  single_request_timeout=DEFAULT_SINGLE_REQUEST_TIMEOUT,
-                 rate_limit_timeout=DEFAULT_RATE_LIMIT_TIMEOUT):
+                 wait_on_rate_limit=DEFAULT_WAIT_ON_RATE_LIMIT):
         """Create a new CiscoSparkAPI object.
 
         An access token must be used when interacting with the Cisco Spark API.
@@ -119,8 +119,13 @@ class CiscoSparkAPI(object):
             base_url(basestring): The base URL to be prefixed to the
                 individual API endpoint suffixes.
                 Defaults to ciscosparkapi.DEFAULT_BASE_URL.
-            timeout(int): Timeout (in seconds) for RESTful HTTP requests.
-                Defaults to ciscosparkapi.DEFAULT_TIMEOUT.
+            timeout(int): [deprecated] Timeout (in seconds) for RESTful HTTP
+                requests. Defaults to ciscosparkapi.DEFAULT_TIMEOUT.
+            single_request_timeout(int): Timeout (in seconds) for RESTful HTTP
+                requests. Defaults to
+                ciscosparkapi.DEFAULT_SINGLE_REQUEST_TIMEOUT.
+            wait_on_rate_limit(bool): Enables or disables automatic rate-limit
+                handling. Defaults to ciscosparkapi.DEFAULT_WAIT_ON_RATE_LIMIT.
 
         Returns:
             CiscoSparkAPI: A new CiscoSparkAPI object.
@@ -151,7 +156,7 @@ class CiscoSparkAPI(object):
             base_url,
             timeout=timeout,
             single_request_timeout=single_request_timeout,
-            rate_limit_timeout=rate_limit_timeout,
+            wait_on_rate_limit=wait_on_rate_limit
         )
 
         # Spark API wrappers
@@ -184,5 +189,5 @@ class CiscoSparkAPI(object):
         return self._session.single_request_timeout
 
     @property
-    def rate_limit_timeout(self):
-        return self._session.rate_limit_timeout
+    def wait_on_rate_limit(self):
+        return self._session.wait_on_rate_limit

--- a/ciscosparkapi/api/accesstokens.py
+++ b/ciscosparkapi/api/accesstokens.py
@@ -28,11 +28,11 @@ import requests
 
 from ciscosparkapi.sparkdata import SparkData
 from ciscosparkapi.utils import (
-    ERC,
     validate_base_url,
     check_response_code,
     extract_and_parse_json,
 )
+from ciscosparkapi.responsecodes import EXPECTED_RESPONSE_CODE
 
 
 __author__ = "Chris Lunsford"
@@ -156,7 +156,7 @@ class AccessTokensAPI(object):
         # API request
         response = requests.post(self._endpoint_url, data=data,
                                  **self._request_kwargs)
-        check_response_code(response, ERC['POST'])
+        check_response_code(response, EXPECTED_RESPONSE_CODE['POST'])
         json_data = extract_and_parse_json(response)
         # Return a AccessToken object created from the response JSON data
         return AccessToken(json_data)
@@ -194,7 +194,7 @@ class AccessTokensAPI(object):
         # API request
         response = requests.post(self._endpoint_url, data=data,
                                  **self._request_kwargs)
-        check_response_code(response, ERC['POST'])
+        check_response_code(response, EXPECTED_RESPONSE_CODE['POST'])
         json_data = extract_and_parse_json(response)
         # Return a AccessToken object created from the response JSON data
         return AccessToken(json_data)

--- a/ciscosparkapi/exceptions.py
+++ b/ciscosparkapi/exceptions.py
@@ -33,6 +33,7 @@ SPARK_RESPONSE_CODES = {
     409: "The request could not be processed because it conflicts with some "
          "established rule of the system. For example, a person may not be "
          "added to a room more than once.",
+    429: "Rate limit exceeded.",
     500: "Something went wrong on the server.",
     503: "Server is overloaded with requests. Try again later."
 }

--- a/ciscosparkapi/exceptions.py
+++ b/ciscosparkapi/exceptions.py
@@ -33,7 +33,10 @@ SPARK_RESPONSE_CODES = {
     409: "The request could not be processed because it conflicts with some "
          "established rule of the system. For example, a person may not be "
          "added to a room more than once.",
-    429: "Rate limit exceeded.",
+    429: "Too many requests have been sent in a given amount of time and the "
+         "request has been rate limited. A Retry-After header should be "
+         "present that specifies how many seconds you need to wait before a "
+         "successful request can be made.",
     500: "Something went wrong on the server.",
     503: "Server is overloaded with requests. Try again later."
 }

--- a/ciscosparkapi/responsecodes.py
+++ b/ciscosparkapi/responsecodes.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+"""Cisco Spark Response Codes."""
+
+
+# Use future for Python v2 and v3 compatibility
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals,
+)
+from builtins import *
+from past.builtins import basestring
+
+
+SPARK_RESPONSE_CODES = {
+    200: "OK",
+    204: "Member deleted.",
+    400: "The request was invalid or cannot be otherwise served. An "
+         "accompanying error message will explain further.",
+    401: "Authentication credentials were missing or incorrect.",
+    403: "The request is understood, but it has been refused or access is not "
+         "allowed.",
+    404: "The URI requested is invalid or the resource requested, such as a "
+         "user, does not exist. Also returned when the requested format is "
+         "not supported by the requested method.",
+    409: "The request could not be processed because it conflicts with some "
+         "established rule of the system. For example, a person may not be "
+         "added to a room more than once.",
+    429: "Too many requests have been sent in a given amount of time and the "
+         "request has been rate limited. A Retry-After header should be "
+         "present that specifies how many seconds you need to wait before a "
+         "successful request can be made.",
+    500: "Something went wrong on the server.",
+    503: "Server is overloaded with requests. Try again later."
+}
+
+RATE_LIMIT_RESPONSE_CODE = 429
+
+EXPECTED_RESPONSE_CODE = {
+    'GET': 200,
+    'POST': 200,
+    'PUT': 200,
+    'DELETE': 204
+}

--- a/ciscosparkapi/restsession.py
+++ b/ciscosparkapi/restsession.py
@@ -25,7 +25,6 @@ from ciscosparkapi.exceptions import ciscosparkapiException, SparkApiError
 from ciscosparkapi.utils import (
     ERC,
     validate_base_url,
-    raise_if_extra_kwargs,
     check_response_code,
     extract_and_parse_json,
 )

--- a/ciscosparkapi/restsession.py
+++ b/ciscosparkapi/restsession.py
@@ -184,18 +184,23 @@ class RestSession(object):
         assert isinstance(headers, dict)
         self._req_session.headers.update(headers)
 
-    def abs_url(self, relative_url):
+    def abs_url(self, url):
         """Convert a relative URL to an absolute URL.
 
         Args:
-            relative_url(basestring): A relative URL.
+            url(basestring): A relative URL.
 
         Returns:
             str: An absolute URL.
 
         """
-        return urllib.parse.urljoin(str(self.base_url),
-                                    str(relative_url))
+        parsed_url = urllib.parse.urlparse(url)
+        if not parsed_url.scheme and not parsed_url.netloc:
+            # url is a relative URL; combine with base_url
+            return urllib.parse.urljoin(str(self.base_url), str(url))
+        else:
+            # url is already an absolute URL; return as is
+            return url
 
     def request(self, method, relative_url, erc, **kwargs):
         """Abstract base method for making requests to the Cisco Spark APIs.

--- a/ciscosparkapi/restsession.py
+++ b/ciscosparkapi/restsession.py
@@ -14,12 +14,14 @@ from past.builtins import basestring
 from future import standard_library
 standard_library.install_aliases()
 
-
+import logging
+import time
 import urllib.parse
+import warnings
 
 import requests
 
-from ciscosparkapi.exceptions import ciscosparkapiException
+from ciscosparkapi.exceptions import ciscosparkapiException, SparkApiError
 from ciscosparkapi.utils import (
     ERC,
     validate_base_url,
@@ -35,6 +37,13 @@ __copyright__ = "Copyright (c) 2016 Cisco Systems, Inc."
 __license__ = "MIT"
 
 
+# Module Constants
+DEFAULT_SINGLE_REQUEST_TIMEOUT = 20
+DEFAULT_RATE_LIMIT_TIMEOUT = 60
+RATE_LIMIT_EXCEEDED_RESPONSE_CODE = 429
+
+
+# Helper Functions
 def _fix_next_url(next_url):
     """Remove max=null parameter from URL.
 
@@ -73,156 +82,376 @@ def _fix_next_url(next_url):
 
 
 class RestSession(object):
-    def __init__(self, access_token, base_url, timeout=None):
+    """RESTful HTTP session class for making calls to the Cisco Spark APIs."""
+
+    def __init__(self, access_token, base_url, timeout=None,
+                 single_request_timeout=DEFAULT_SINGLE_REQUEST_TIMEOUT,
+                 rate_limit_timeout=DEFAULT_RATE_LIMIT_TIMEOUT):
+        """Initialize a new RestSession object."""
         super(RestSession, self).__init__()
+
+        # Initialize attributes and properties
         self._base_url = str(validate_base_url(base_url))
         self._access_token = access_token
+        self._single_request_timeout = single_request_timeout
+        self._rate_limit_timeout = rate_limit_timeout
+        if timeout:
+            self.timeout = timeout
+
+        # Initialize a new `requests` session
         self._req_session = requests.session()
-        self._timeout = None
+
+        # Update the headers of the `requests` session
         self.update_headers({'Authorization': 'Bearer ' + access_token,
                              'Content-type': 'application/json;charset=utf-8'})
-        self.timeout = timeout
 
     @property
     def base_url(self):
+        """The base URL for the API endpoints."""
         return self._base_url
 
     @property
     def access_token(self):
+        """The Cisco Spark access token used for this session."""
         return self._access_token
 
     @property
-    def headers(self):
-        return self._req_session.headers.copy()
-
-    def update_headers(self, headers):
-        assert isinstance(headers, dict)
-        self._req_session.headers.update(headers)
-
-    @property
     def timeout(self):
-        return self._timeout
+        """[Deprecated] The timeout (seconds) for an API request.
+
+        We are deprecating the timeout property in favor of the more
+        descriptive single_request_timeout property.
+
+        """
+        warnings.warn("The 'timeout' property is being deprecated. Please use "
+                      "the 'single_request_timeout' instead.",
+                      DeprecationWarning)
+        return self._single_request_timeout
 
     @timeout.setter
     def timeout(self, value):
-        assert value is None or value > 0
-        self._timeout = value
+        """[Deprecated] The timeout (seconds) for an API request.
 
-    def urljoin(self, suffix_url):
-        return urllib.parse.urljoin(str(self.base_url), str(suffix_url))
+        We are deprecating the timeout property in favor of the more
+        descriptive single_request_timeout property.
+
+        """
+        warnings.warn("The 'timeout' property is being deprecated. Please use "
+                      "the 'single_request_timeout' instead.",
+                      DeprecationWarning)
+        assert value is None or value > 0
+        self._single_request_timeout = value
+
+    @property
+    def single_request_timeout(self):
+        """The timeout (seconds) for a single HTTP REST API request."""
+        return self._single_request_timeout
+
+    @single_request_timeout.setter
+    def single_request_timeout(self, value):
+        """The timeout (seconds) for a single HTTP REST API request."""
+        assert value is None or value > 0
+        self._single_request_timeout = value
+
+    @property
+    def rate_limit_timeout(self):
+        """Maximum time (s) to wait for a response with rate-limit handling."""
+        return self._rate_limit_timeout
+
+    @rate_limit_timeout.setter
+    def rate_limit_timeout(self, value):
+        """Maximum time (s) to wait for a response with rate-limit handling."""
+        assert value is None or value > 0
+        self._rate_limit_timeout = value
+
+    @property
+    def headers(self):
+        """The HTTP headers used for requests in this session."""
+        return self._req_session.headers.copy()
+
+    def update_headers(self, headers):
+        """Update the HTTP headers used for requests in this session.
+
+        Note: Updates provided by the dictionary passed as the `headers`
+        parameter to this method are merged into the session headers by adding
+        new key-value pairs and/or updating the values of existing keys. The
+        session headers are not replaced by the provided dictionary.
+
+        Args:
+             headers(dict): Updates to the current session headers.
+
+        """
+        assert isinstance(headers, dict)
+        self._req_session.headers.update(headers)
+
+    def abs_url(self, relative_url):
+        """Convert a relative URL to an absolute URL.
+
+        Args:
+            relative_url(basestring): A relative URL.
+
+        Returns:
+            str: An absolute URL.
+
+        """
+        return urllib.parse.urljoin(str(self.base_url),
+                                    str(relative_url))
+
+    def request(self, method, relative_url, erc, **kwargs):
+        """Abstract base method for making requests to the Cisco Spark APIs.
+
+        This base method:
+            * Expands the relative API endpoint URL to an absolute URL
+            * Makes the actual HTTP request to the API endpoint
+            * Provides support for Spark rate-limiting
+            * Inspects response codes and raises exceptions as appropriate
+
+        Args:
+            method(basestring): The request-method type ('GET', 'POST', etc.).
+            relative_url(basestring): The relative URL of the API endpoint to
+                be called.
+            erc(int): The expected response code that should be returned by the
+                Cisco Spark API endpoint to indicate success.
+            **kwargs: Passed on to the requests package.
+
+        Raises:
+            SparkApiError: If anything other than the expected response code is
+                returned by the Cisco Spark API endpoint.
+
+        """
+        logger = logging.getLogger(__name__)
+
+        # Expand the relative API endpoint URL to an absolute URL
+        abs_url = self.abs_url(relative_url)
+
+        # Update request kwargs with session defaults
+        kwargs.setdefault('timeout', self.single_request_timeout)
+
+        start_time = time.time()
+        finish_time = start_time + self.rate_limit_timeout
+
+        while True:
+            # Make the HTTP request to the API endpoint
+            response = self._req_session.request(method, abs_url, **kwargs)
+
+            try:
+                # Check the response code for error conditions
+                check_response_code(response, erc)
+
+            except SparkApiError as e:
+
+                # Catch rate-limit errors
+                if e.response_code == RATE_LIMIT_EXCEEDED_RESPONSE_CODE \
+                        and response.headers.get('Retry-After'):
+
+                    logger.debug("Received a [{}] {} response."
+                                 "".format(e.response_code, e.response_text))
+
+                    rate_limit_wait = response.headers['Retry-After']
+
+                    if self.rate_limit_timeout is None:
+                        # Retry indefinitely
+                        logger.debug("Waiting {:0.3f} seconds. "
+                                     "rate_limit_timeout is None; "
+                                     "will retry indefinitely."
+                                     "".format(rate_limit_wait))
+                        time.sleep(rate_limit_wait)
+                        continue
+                    elif time.time() + rate_limit_wait < finish_time:
+                        # Retry if doing so will not exceed the finish time
+                        logger.debug("Waiting {:0.3f} seconds. "
+                                     "rate_limit_timeout is {:0.3f} seconds, "
+                                     "maximum time remaining for this request "
+                                     "is {:0.3f} seconds."
+                                     "".format(rate_limit_wait,
+                                               self.rate_limit_timeout,
+                                               finish_time - time.time()))
+                        time.sleep(rate_limit_wait)
+                        continue
+                    else:
+                        # Time exceeded re-raise the rate limit SparkApiError
+                        raise
+
+                else:
+                    # Some other SparkApiError (re-raise)
+                    raise
+
+            else:
+                # No errors - return the response object
+                return response
 
     def get(self, url, params=None, **kwargs):
-        # Process args
+        """Sends a GET request.
+
+        Args:
+            url(basestring): The relative URL of the API endpoint.
+            params(dict): The parameters for the HTTP GET request.
+            **kwargs:
+                erc(int): The expected (success) response code for the request.
+                others: Passed on to the requests package.
+
+        Raises:
+            SparkApiError: If anything other than the expected response code is
+                returned by the Cisco Spark API endpoint.
+
+        """
         assert isinstance(url, basestring)
         assert params is None or isinstance(params, dict)
-        abs_url = self.urljoin(url)
-        # Process kwargs
-        timeout = kwargs.pop('timeout', self.timeout)
+
+        # Expected response code
         erc = kwargs.pop('erc', ERC['GET'])
-        raise_if_extra_kwargs(kwargs)
-        # API request
-        response = self._req_session.get(abs_url, params=params,
-                                         timeout=timeout)
-        # Process response
-        check_response_code(response, erc)
+
+        response = self.request('GET', url, erc, params=params, **kwargs)
         return extract_and_parse_json(response)
 
     def get_pages(self, url, params=None, **kwargs):
-        # Process args
+        """Return a generator that GETs and yields pages of data.
+
+        Provides native support for RFC5988 Web Linking.
+
+        Args:
+            url(basestring): The relative URL of the API endpoint.
+            params(dict): The parameters for the HTTP GET request.
+            **kwargs:
+                erc(int): The expected (success) response code for the request.
+                others: Passed on to the requests package.
+
+        Raises:
+            SparkApiError: If anything other than the expected response code is
+                returned by the Cisco Spark API endpoint.
+
+        """
         assert isinstance(url, basestring)
         assert params is None or isinstance(params, dict)
-        abs_url = self.urljoin(url)
-        # Process kwargs
-        timeout = kwargs.pop('timeout', self.timeout)
+
+        # Expected response code
         erc = kwargs.pop('erc', ERC['GET'])
-        raise_if_extra_kwargs(kwargs)
-        # API request - get first page
-        response = self._req_session.get(abs_url, params=params,
-                                         timeout=timeout)
+
+        # First request
+        response = self.request('GET', url, erc, params=params, **kwargs)
+
         while True:
-            # Process response - Yield page's JSON data
-            check_response_code(response, erc)
             yield extract_and_parse_json(response)
-            # Get next page
+
             if response.links.get('next'):
                 next_url = response.links.get('next').get('url')
+
+                # TODO: Test to see if fix is still needed.
                 # Patch for Cisco Spark 'max=null' in next URL bug.
-                next_url = _fix_next_url(next_url)
-                # API request - get next page
-                response = self._req_session.get(next_url, timeout=timeout)
+                # url = _fix_next_url(next_url)
+
+                # Subsequent requests
+                response = self.request('GET', next_url, erc, **kwargs)
+
             else:
-                raise StopIteration
+                break
 
     def get_items(self, url, params=None, **kwargs):
-        # Get iterator for pages of JSON data
+        """Return a generator that GETs and yields individual JSON `items`.
+
+        Yields individual `items` from Cisco Spark's top-level {'items': [...]}
+        JSON objects. Provides native support for RFC5988 Web Linking.  The
+        generator will request additional pages as needed until all items have
+        been returned.
+
+        Args:
+            url(basestring): The relative URL of the API endpoint.
+            params(dict): The parameters for the HTTP GET request.
+            **kwargs:
+                erc(int): The expected (success) response code for the request.
+                others: Passed on to the requests package.
+
+        Raises:
+            SparkApiError: If anything other than the expected response code is
+                returned by the Cisco Spark API endpoint.
+            ciscosparkapiException: If the returned response does not contain a
+                top-level dictionary with an 'items' key.
+
+        """
+        # Get generator for pages of JSON data
         pages = self.get_pages(url, params=params, **kwargs)
-        # Process pages
+
         for json_page in pages:
-            # Process each page of JSON data yielding the individual JSON
-            # objects contained within the top level 'items' array
             assert isinstance(json_page, dict)
-            items = json_page.get(u'items')
+
+            items = json_page.get('items')
+
             if items is None:
-                error_message = "'items' object not found in JSON data: " \
+                error_message = "'items' key not found in JSON data: " \
                                 "{!r}".format(json_page)
                 raise ciscosparkapiException(error_message)
+
             else:
                 for item in items:
                     yield item
 
-    def post(self, url, json=None, data=None, headers=None, **kwargs):
-        # Process args
+    def post(self, url, json=None, data=None, **kwargs):
+        """Sends a POST request.
+
+        Args:
+            url(basestring): The relative URL of the API endpoint.
+            json: Data to be sent in JSON format in tbe body of the request.
+            data: Data to be sent in the body of the request.
+            **kwargs:
+                erc(int): The expected (success) response code for the request.
+                others: Passed on to the requests package.
+
+        Raises:
+            SparkApiError: If anything other than the expected response code is
+                returned by the Cisco Spark API endpoint.
+
+        """
         assert isinstance(url, basestring)
-        abs_url = self.urljoin(url)
-        # Process listed kwargs
-        request_args = {}
-        assert json is None or isinstance(json, dict)
-        assert headers is None or isinstance(headers, dict)
-        if json and data:
-            raise TypeError("You must provide either a json or data argument, "
-                            "not both.")
-        elif json:
-            request_args['json'] = json
-        elif data:
-            request_args['data'] = data
-        elif not json and not data:
-            raise TypeError("You must provide either a json or data argument.")
-        if headers:
-            request_args['headers'] = headers
-        # Process unlisted kwargs
-        request_args['timeout'] = kwargs.pop('timeout', self.timeout)
+
+        # Expected response code
         erc = kwargs.pop('erc', ERC['POST'])
-        raise_if_extra_kwargs(kwargs)
-        # API request
-        response = self._req_session.post(abs_url, **request_args)
-        # Process response
-        check_response_code(response, erc)
+
+        response = self.request('POST', url, erc, json=json, data=data,
+                                **kwargs)
         return extract_and_parse_json(response)
 
-    def put(self, url, json, **kwargs):
-        # Process args
+    def put(self, url, json=None, data=None, **kwargs):
+        """Sends a PUT request.
+
+        Args:
+            url(basestring): The relative URL of the API endpoint.
+            json: Data to be sent in JSON format in tbe body of the request.
+            data: Data to be sent in the body of the request.
+            **kwargs:
+                erc(int): The expected (success) response code for the request.
+                others: Passed on to the requests package.
+
+        Raises:
+            SparkApiError: If anything other than the expected response code is
+                returned by the Cisco Spark API endpoint.
+
+        """
         assert isinstance(url, basestring)
-        assert isinstance(json, dict)
-        abs_url = self.urljoin(url)
-        # Process kwargs
-        timeout = kwargs.pop('timeout', self.timeout)
+
+        # Expected response code
         erc = kwargs.pop('erc', ERC['PUT'])
-        raise_if_extra_kwargs(kwargs)
-        # API request
-        response = self._req_session.put(abs_url, json=json, timeout=timeout)
-        # Process response
-        check_response_code(response, erc)
+
+        response = self.request('PUT', url, erc, json=json, data=data,
+                                **kwargs)
         return extract_and_parse_json(response)
 
     def delete(self, url, **kwargs):
-        # Process args
+        """Sends a DELETE request.
+
+        Args:
+            url(basestring): The relative URL of the API endpoint.
+            **kwargs:
+                erc(int): The expected (success) response code for the request.
+                others: Passed on to the requests package.
+
+        Raises:
+            SparkApiError: If anything other than the expected response code is
+                returned by the Cisco Spark API endpoint.
+
+        """
         assert isinstance(url, basestring)
-        abs_url = self.urljoin(url)
-        # Process kwargs
-        timeout = kwargs.pop('timeout', self.timeout)
+
+        # Expected response code
         erc = kwargs.pop('erc', ERC['DELETE'])
-        raise_if_extra_kwargs(kwargs)
-        # API request
-        response = self._req_session.delete(abs_url, timeout=timeout)
-        # Process response
-        check_response_code(response, erc)
+
+        self.request('DELETE', url, erc, **kwargs)

--- a/ciscosparkapi/restsession.py
+++ b/ciscosparkapi/restsession.py
@@ -267,8 +267,8 @@ class RestSession(object):
                 if e.response_code == RATE_LIMIT_EXCEEDED_RESPONSE_CODE \
                         and response.headers.get('Retry-After'):
 
-                    logger.debug("Received a [{}] {} response."
-                                 "".format(e.response_code, e.response_text))
+                    logger.debug("Received a [%s] rate limit response. "
+                                 "Attempting to retry.", e.response_code)
 
                     rate_limit_wait = response.headers['Retry-After']
 

--- a/ciscosparkapi/restsession.py
+++ b/ciscosparkapi/restsession.py
@@ -37,8 +37,8 @@ __license__ = "MIT"
 
 
 # Module Constants
-DEFAULT_SINGLE_REQUEST_TIMEOUT = 20
-DEFAULT_RATE_LIMIT_TIMEOUT = 60
+DEFAULT_SINGLE_REQUEST_TIMEOUT = 20.0
+DEFAULT_RATE_LIMIT_TIMEOUT = 60.0
 RATE_LIMIT_EXCEEDED_RESPONSE_CODE = 429
 
 
@@ -96,9 +96,9 @@ class RestSession(object):
 
         # Initialize attributes and properties
         self._base_url = str(validate_base_url(base_url))
-        self._access_token = access_token
-        self._single_request_timeout = single_request_timeout
-        self._rate_limit_timeout = rate_limit_timeout
+        self._access_token = str(access_token)
+        self._single_request_timeout = float(single_request_timeout)
+        self._rate_limit_timeout = float(rate_limit_timeout)
         if timeout:
             self.timeout = timeout
 
@@ -144,7 +144,7 @@ class RestSession(object):
                       "the 'single_request_timeout' instead.",
                       DeprecationWarning)
         assert value is None or value > 0
-        self._single_request_timeout = value
+        self._single_request_timeout = float(value)
 
     @property
     def single_request_timeout(self):

--- a/ciscosparkapi/restsession.py
+++ b/ciscosparkapi/restsession.py
@@ -85,13 +85,27 @@ def _fix_next_url(next_url):
     return urllib.parse.urlunparse(parsed_url)
 
 
+# Main module interface
 class RestSession(object):
     """RESTful HTTP session class for making calls to the Cisco Spark APIs."""
 
     def __init__(self, access_token, base_url, timeout=None,
                  single_request_timeout=DEFAULT_SINGLE_REQUEST_TIMEOUT,
                  rate_limit_timeout=DEFAULT_RATE_LIMIT_TIMEOUT):
-        """Initialize a new RestSession object."""
+        """Initialize a new RestSession object.
+
+        Args:
+            access_token(basestring): The Spark access token to be used for
+                this session.
+            base_url(basestring): The base URL that will be suffixed onto the
+                API endpoint relative URLs to produce a callable absolute URL.
+            timeout: [Deprecated] The timeout (seconds) for an API request.
+            single_request_timeout(float): The timeout (seconds) for a single
+                HTTP REST API request.
+            rate_limit_timeout(float): Maximum time (seconds) to wait for a
+                response with rate-limit handling.
+
+        """
         super(RestSession, self).__init__()
 
         # Initialize attributes and properties

--- a/tests/test_ciscosparkapi.py
+++ b/tests/test_ciscosparkapi.py
@@ -80,17 +80,17 @@ class TestCiscoSparkAPI:
         )
         assert connection_object.single_request_timeout == custom_timeout
 
-    def test_default_rate_limit_timeout(self):
+    def test_default_wait_on_rate_limit(self):
         connection_object = ciscosparkapi.CiscoSparkAPI()
-        assert connection_object.rate_limit_timeout == \
-               ciscosparkapi.DEFAULT_RATE_LIMIT_TIMEOUT
+        assert connection_object.wait_on_rate_limit == \
+               ciscosparkapi.DEFAULT_WAIT_ON_RATE_LIMIT
 
-    def test_custom_rate_limit_timeout(self):
-        custom_timeout = 10
+    def test_non_default_wait_on_rate_limit(self):
         connection_object = ciscosparkapi.CiscoSparkAPI(
-                rate_limit_timeout=custom_timeout
+                wait_on_rate_limit=not ciscosparkapi.DEFAULT_WAIT_ON_RATE_LIMIT
         )
-        assert connection_object.rate_limit_timeout == custom_timeout
+        assert connection_object.wait_on_rate_limit != \
+               ciscosparkapi.DEFAULT_WAIT_ON_RATE_LIMIT
 
     # Test creation of component API objects
 

--- a/tests/test_ciscosparkapi.py
+++ b/tests/test_ciscosparkapi.py
@@ -60,12 +60,37 @@ class TestCiscoSparkAPI:
 
     def test_default_timeout(self):
         connection_object = ciscosparkapi.CiscoSparkAPI()
-        assert connection_object.timeout == ciscosparkapi.DEFAULT_TIMEOUT
+        assert connection_object.timeout == \
+               ciscosparkapi.DEFAULT_SINGLE_REQUEST_TIMEOUT
 
     def test_custom_timeout(self):
         custom_timeout = 10
         connection_object = ciscosparkapi.CiscoSparkAPI(timeout=custom_timeout)
         assert connection_object.timeout == custom_timeout
+
+    def test_default_single_request_timeout(self):
+        connection_object = ciscosparkapi.CiscoSparkAPI()
+        assert connection_object.single_request_timeout == \
+               ciscosparkapi.DEFAULT_SINGLE_REQUEST_TIMEOUT
+
+    def test_custom_single_request_timeout(self):
+        custom_timeout = 10
+        connection_object = ciscosparkapi.CiscoSparkAPI(
+                single_request_timeout=custom_timeout
+        )
+        assert connection_object.single_request_timeout == custom_timeout
+
+    def test_default_rate_limit_timeout(self):
+        connection_object = ciscosparkapi.CiscoSparkAPI()
+        assert connection_object.rate_limit_timeout == \
+               ciscosparkapi.DEFAULT_RATE_LIMIT_TIMEOUT
+
+    def test_custom_rate_limit_timeout(self):
+        custom_timeout = 10
+        connection_object = ciscosparkapi.CiscoSparkAPI(
+                rate_limit_timeout=custom_timeout
+        )
+        assert connection_object.rate_limit_timeout == custom_timeout
 
     # Test creation of component API objects
 

--- a/tests/test_restsession.py
+++ b/tests/test_restsession.py
@@ -6,11 +6,6 @@ import logging
 
 import pytest
 
-from ciscosparkapi.restsession import (
-    RATE_LIMIT_RESPONSE_CODE,
-    RATE_LIMIT_LOG_MESSAGE
-)
-
 
 # Helper Classes
 class RateLimitDetector(logging.Handler):
@@ -25,9 +20,7 @@ class RateLimitDetector(logging.Handler):
         """Check record to see if it is a rate-limit message."""
         assert isinstance(record, logging.LogRecord)
 
-        if (RATE_LIMIT_RESPONSE_CODE in record.args
-                and record.msg == RATE_LIMIT_LOG_MESSAGE):
-
+        if record.msg.startswith("Received rate-limit message"):
             self.rate_limit_detected = True
 
 

--- a/tests/test_restsession.py
+++ b/tests/test_restsession.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+"""ciscosparkapi/restsession.py Fixtures & Tests"""
+
+
+import logging
+
+import pytest
+
+from ciscosparkapi.exceptions import SPARK_RESPONSE_CODES
+
+# Constants
+RATE_LIMIT_RESPONSE_CODE = 429
+RATE_LIMIT_RESPONSE_TEXT = SPARK_RESPONSE_CODES[RATE_LIMIT_RESPONSE_CODE]
+RATE_LIMIT_LOG_MESSAGE = ("Received a [%s] rate limit response. "
+                          "Attempting to retry.")
+
+
+# Helper Classes
+class RateLimitDetector(logging.Handler):
+    """Detects occurrences of rate limiting."""
+
+    def __init__(self):
+        super(RateLimitDetector, self).__init__()
+
+        self.rate_limit_detected = False
+
+    def emit(self, record):
+        """Check record to see if it is a rate-limit message."""
+        assert isinstance(record, logging.LogRecord)
+
+        if (RATE_LIMIT_RESPONSE_CODE in record.args
+                and record.msg == RATE_LIMIT_LOG_MESSAGE):
+
+            self.rate_limit_detected = True
+
+
+# CiscoSparkAPI Tests
+class TestRestSession:
+    """Test edge cases of core RestSession functionality."""
+
+    @pytest.mark.ratelimit
+    def test_rate_limit_support(self, api, rooms_list, add_rooms):
+        # Add log handler
+        root_logger = logging.getLogger()
+        rate_limit_detector = RateLimitDetector()
+        root_logger.addHandler(rate_limit_detector)
+
+        try:
+            # Try and trigger a rate-limit
+            rooms = api.rooms.list(max=1)
+            while not rate_limit_detector.rate_limit_detected:
+                for room in rooms:
+                    # Do nothing
+                    pass
+
+        finally:
+            # Remove the log handler
+            root_logger.removeHandler(rate_limit_detector)
+
+        assert rate_limit_detector.rate_limit_detected == True

--- a/tox.ini
+++ b/tox.ini
@@ -3,5 +3,5 @@ envlist = py27, py36
 
 [testenv]
 deps = pytest
-commands = py.test
+commands = py.test -m "not ratelimit"
 passenv = SPARK_ACCESS_TOKEN


### PR DESCRIPTION
I added a new automatic rate-limit handling feature (enabled by default), which catches Spark rate-limit responses (response code 429) and automatically retries the request after waiting `Retry-After` seconds (supplied by Cisco Spark in the rate-limit response's header).

While implementing this feature, I refactored and enhanced a number of the packages base modules including:
 * The rest session module and class
 * The response codes (location and definitions)
 * The exceptions module and classes

All tests were passing before the modifications, and all tests are passing after the changes (including the new test cases created for the new functionality).