### PR TITLE
Include orgId parameter for people list method

### DIFF
--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -137,7 +137,7 @@ class PeopleAPI(object):
         self._session = session
 
     @generator_container
-    def list(self, email=None, displayName=None, orgId=None, max=None):
+    def list(self, email=None, displayName=None, orgId=None, id=None, max=None):
         """List people
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -154,6 +154,7 @@ class PeopleAPI(object):
             email(basestring): The e-mail address of the person to be found.
             displayName(basestring): The complete or beginning portion of
                 the displayName to be searched.
+            id(basestring): List people by ID. Accepts up to 85 person IDs separated by commas.
             orgId(basestring): The organization id.
             max(int): Limits the maximum number of people returned from the
                 Spark service per request.
@@ -171,16 +172,20 @@ class PeopleAPI(object):
         assert email is None or isinstance(email, basestring)
         assert displayName is None or isinstance(displayName, basestring)
         assert orgId is None or isinstance(orgId, basestring)
+        assert id is None or isinstance(id, basestring)
         assert max is None or isinstance(max, int)
         params = {}
-        if email:
-            params['email'] = email
-        elif displayName:
-            params['displayName'] = displayName
-        if orgId:
-            params["orgId"] = orgId
-        if max:
-            params['max'] = max
+        if id:
+            params["id"] = id
+        else:
+            if email:
+                params['email'] = email
+            elif displayName:
+                params['displayName'] = displayName
+            if orgId:
+                params["orgId"] = orgId
+            if max:
+                params['max'] = max
         # API request - get items
         items = self._session.get_items('people', params=params)
         # Yield Person objects created from the returned items JSON objects

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -137,7 +137,7 @@ class PeopleAPI(object):
         self._session = session
 
     @generator_container
-    def list(self, email=None, displayName=None, max=None):
+    def list(self, email=None, displayName=None, orgId=None, max=None):
         """List people
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -154,6 +154,7 @@ class PeopleAPI(object):
             email(basestring): The e-mail address of the person to be found.
             displayName(basestring): The complete or beginning portion of
                 the displayName to be searched.
+            orgId(basestring): The organization id.
             max(int): Limits the maximum number of people returned from the
                 Spark service per request.
 
@@ -169,12 +170,15 @@ class PeopleAPI(object):
         # Process args
         assert email is None or isinstance(email, basestring)
         assert displayName is None or isinstance(displayName, basestring)
+        assert orgId is None or isinstance(orgId, basestring)
         assert max is None or isinstance(max, int)
         params = {}
         if email:
             params['email'] = email
         elif displayName:
             params['displayName'] = displayName
+        if orgId:
+            params["orgId"] = orgId
         if max:
             params['max'] = max
         # API request - get items

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -177,15 +177,14 @@ class PeopleAPI(object):
         params = {}
         if id:
             params["id"] = id
-        else:
-            if email:
+        elif email:
                 params['email'] = email
-            elif displayName:
-                params['displayName'] = displayName
-            if orgId:
-                params["orgId"] = orgId
-            if max:
-                params['max'] = max
+        elif displayName:
+            params['displayName'] = displayName
+        if orgId:
+            params["orgId"] = orgId
+        if max:
+            params['max'] = max
         # Process query_param keyword arguments
         if query_params:
             params.update(query_params)

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -137,7 +137,7 @@ class PeopleAPI(object):
         self._session = session
 
     @generator_container
-    def list(self, email=None, displayName=None, orgId=None, id=None, max=None):
+    def list(self, email=None, displayName=None, orgId=None, id=None, max=None, **query_params):
         """List people
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -186,6 +186,9 @@ class PeopleAPI(object):
                 params["orgId"] = orgId
             if max:
                 params['max'] = max
+        # Process query_param keyword arguments
+        if query_params:
+            params.update(query_params)
         # API request - get items
         items = self._session.get_items('people', params=params)
         # Yield Person objects created from the returned items JSON objects

--- a/tests/api/test_people.py
+++ b/tests/api/test_people.py
@@ -180,6 +180,12 @@ class TestPeopleAPI(object):
         assert len(list_of_people) >= 1
         assert are_valid_people(list_of_people)
 
+    def test_list_people_by_id(self, api, test_people):
+        id = test_people["not_a_member"].id
+        list_of_people = list_people(api, id=id)
+        assert len(list_of_people) >= 1
+        assert are_valid_people(list_of_people)
+
     def test_list_people_with_paging(self, api, test_people,
                                      additional_group_room_memberships):
         page_size = 1


### PR DESCRIPTION
The people list API now supports the orgId parameter to send the organization id of where you want to scope your search.

I'm creating this pull request to fix issue #44 however, this should not be merged just yet. I need to include the tests for this change.

This first commit is to show the code change to @gj0nyg.