### PR TITLE
Issue 44 - Cisco Spark API Updates & Package Refactoring to Improve Future-Proofing

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E402,F401,F403
+ignore = E402,F401,F403,F405,W503
 exclude =
     .git,
     __pycache__,

--- a/ciscosparkapi/__init__.py
+++ b/ciscosparkapi/__init__.py
@@ -30,7 +30,7 @@ from ciscosparkapi.api.teammemberships import (
     TeamMembership,
     TeamMembershipsAPI
 )
-from ciscosparkapi.api.webhooks import Webhook, WebhooksAPI
+from ciscosparkapi.api.webhooks import Webhook, WebhookEvent, WebhooksAPI
 from ciscosparkapi.api.organizations import Organization, OrganizationsAPI
 from ciscosparkapi.api.licenses import License, LicensesAPI
 from ciscosparkapi.api.roles import Role, RolesAPI

--- a/ciscosparkapi/api/licenses.py
+++ b/ciscosparkapi/api/licenses.py
@@ -51,7 +51,7 @@ class License(SparkData):
 
     @property
     def id(self):
-        """The unique id for the License."""
+        """The unique ID for the License."""
         return self._json.get('id')
 
     @property

--- a/ciscosparkapi/api/memberships.py
+++ b/ciscosparkapi/api/memberships.py
@@ -251,11 +251,13 @@ class MembershipsAPI(object):
         return Membership(json_data)
 
     def update(self, membershipId, isModerator=None, **request_parameters):
-        """Updates properties for a membership, by ID.
+        """Update properties for a membership, by ID.
 
         Args:
             membershipId(basestring): The membership ID.
             isModerator(bool): Set to True to make the person a room moderator.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
             Membership: A Membership object with the updated Spark membership
@@ -276,7 +278,7 @@ class MembershipsAPI(object):
 
         # API request
         json_data = self._session.put('memberships/' + membershipId,
-                                     json=put_data)
+                                      json=put_data)
 
         # Return a Membership object created from the response JSON data
         return Membership(json_data)

--- a/ciscosparkapi/api/memberships.py
+++ b/ciscosparkapi/api/memberships.py
@@ -4,8 +4,8 @@
 Classes:
     Membership: Models a Spark 'membership' JSON object as a native Python
         object.
-    MembershipsAPI: Wrappers the Cisco Spark Memberships-API and exposes the
-        API calls as Python method calls that return native Python objects.
+    MembershipsAPI: Wraps the Cisco Spark Memberships-API and exposes the
+        APIs as native Python methods that return native Python objects.
 
 """
 
@@ -20,10 +20,13 @@ from __future__ import (
 from builtins import *
 from past.builtins import basestring
 
-from ciscosparkapi.exceptions import ciscosparkapiException
-from ciscosparkapi.utils import generator_container
 from ciscosparkapi.restsession import RestSession
 from ciscosparkapi.sparkdata import SparkData
+from ciscosparkapi.utils import (
+    check_type,
+    dict_from_items_with_values,
+    generator_container,
+)
 
 
 __author__ = "Chris Lunsford"
@@ -36,10 +39,10 @@ class Membership(SparkData):
     """Model a Spark 'membership' JSON object as a native Python object."""
 
     def __init__(self, json):
-        """Init a new Membership data object from a JSON dictionary or string.
+        """Initialize a Membership object from a dictionary or JSON string.
 
         Args:
-            json(dict, basestring): Input JSON object.
+            json(dict, basestring): Input dictionary or JSON string.
 
         Raises:
             TypeError: If the input object is not a dictionary or string.
@@ -49,42 +52,55 @@ class Membership(SparkData):
 
     @property
     def id(self):
-        return self._json['id']
+        """The membership's unique ID."""
+        return self._json.get('id')
 
     @property
     def roomId(self):
-        return self._json['roomId']
+        """The ID of the room."""
+        return self._json.get('roomId')
 
     @property
     def personId(self):
-        return self._json['personId']
+        """The ID of the person."""
+        return self._json.get('personId')
 
     @property
     def personEmail(self):
-        return self._json['personEmail']
+        """The email address of the person."""
+        return self._json.get('personEmail')
 
     @property
     def personDisplayName(self):
-        return self._json['personDisplayName']
+        """The display name of the person."""
+        return self._json.get('personDisplayName')
+
+    @property
+    def personOrgId(self):
+        """The ID of the organization that the person is associated with."""
+        return self._json.get('personOrgId')
 
     @property
     def isModerator(self):
-        return self._json['isModerator']
+        """Person is a moderator for the room."""
+        return self._json.get('isModerator')
 
     @property
     def isMonitor(self):
-        return self._json['isMonitor']
+        """Person is a monitor for the room."""
+        return self._json.get('isMonitor')
 
     @property
     def created(self):
-        return self._json['created']
+        """The date and time the membership was created."""
+        return self._json.get('created')
 
 
 class MembershipsAPI(object):
     """Cisco Spark Memberships-API wrapper class.
 
-    Wrappers the Cisco Spark Memberships-API and exposes the API calls as
-    Python method calls that return native Python objects.
+    Wraps the Cisco Spark Memberships-API and exposes the APIs as native Python
+    methods that return native Python objects.
 
     """
 
@@ -96,25 +112,28 @@ class MembershipsAPI(object):
                 API calls to the Cisco Spark service.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
 
         """
-        assert isinstance(session, RestSession)
+        check_type(session, RestSession)
+
         super(MembershipsAPI, self).__init__()
+
         self._session = session
 
     @generator_container
-    def list(self, roomId=None, personId=None, personEmail=None, max=None):
+    def list(self, roomId=None, personId=None, personEmail=None, max=None,
+             **request_parameters):
         """List room memberships.
 
-        By default, lists memberships for rooms to which the authenticated
-        user belongs.
+        By default, lists memberships for rooms to which the authenticated user
+        belongs.
 
         Use query parameters to filter the response.
 
-        Use roomId to list memberships for a room, by ID.
+        Use `roomId` to list memberships for a room, by ID.
 
-        Use either personId or personEmail to filter the results.
+        Use either `personId` or `personEmail` to filter the results.
 
         This method supports Cisco Spark's implementation of RFC5988 Web
         Linking to provide pagination support.  It returns a generator
@@ -127,164 +146,153 @@ class MembershipsAPI(object):
         container.
 
         Args:
-            roomId(basestring): List memberships for the room with roomId.
-            personId(basestring): Filter results to include only those with
-                personId.
-            personEmail(basestring): Filter results to include only those
-                with personEmail.
-            max(int): Limits the maximum number of memberships returned from
-                the Spark service per request.
-
+            roomId(basestring): Limit results to a specific room, by ID.
+            personId(basestring): Limit results to a specific person, by ID.
+            personEmail(basestring): Limit results to a specific person, by
+                email address.
+            max(int): Limit the maximum number of items returned from the Spark
+                service per request.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            GeneratorContainer: When iterated, the GeneratorContainer, yields
-                the memberships returned from the Cisco Spark query.
+            GeneratorContainer: A GeneratorContainer which, when iterated,
+                yields the memberships returned by the Cisco Spark query.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
-            ciscosparkapiException: If a personId or personEmail argument is
-                specified without providing a roomId argument.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert roomId is None or isinstance(roomId, basestring)
-        assert personId is None or isinstance(personId, basestring)
-        assert personEmail is None or isinstance(personEmail, basestring)
-        assert max is None or isinstance(max, int)
-        params = {}
-        if roomId:
-            params['roomId'] = roomId
-            if personId:
-                params['personId'] = personId
-            elif personEmail:
-                params['personEmail'] = personEmail
-        elif personId or personEmail:
-            error_message = "A roomId must be specified. A personId or " \
-                            "personEmail filter may only be specified when " \
-                            "requesting the memberships for a room with the " \
-                            "roomId argument."
-            raise ciscosparkapiException(error_message)
-        if max:
-            params['max'] = max
+        check_type(roomId, basestring)
+        check_type(personId, basestring)
+        check_type(personEmail, basestring)
+        check_type(max, int)
+
+        params = dict_from_items_with_values(
+                request_parameters,
+                roomId=roomId,
+                personId=personId,
+                personEmail=personEmail,
+                max=max,
+        )
+
         # API request - get items
         items = self._session.get_items('memberships', params=params)
+
         # Yield Person objects created from the returned items JSON objects
         for item in items:
             yield Membership(item)
 
     def create(self, roomId, personId=None, personEmail=None,
-               isModerator=False):
+               isModerator=False, **request_parameters):
         """Add someone to a room by Person ID or email address.
 
         Add someone to a room by Person ID or email address; optionally
         making them a moderator.
 
         Args:
-            roomId(basestring): ID of the room to which the person will be
-                added.
-            personId(basestring): ID of the person to be added to the room.
-            personEmail(basestring): Email address of the person to be added
-                to the room.
-            isModerator(bool): If True, adds the person as a moderator for the
-                room. If False, adds the person as normal member of the room.
+            roomId(basestring): The room ID.
+            personId(basestring): The ID of the person.
+            personEmail(basestring): The email address of the person.
+            isModerator(bool): Set to True to make the person a room moderator.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            Membership: With the details of the created membership.
+            Membership: A Membership object with the details of the created
+                membership.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
-            ciscosparkapiException: If neither a personId or personEmail are
-                provided.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(roomId, basestring)
-        assert personId is None or isinstance(personId, basestring)
-        assert personEmail is None or isinstance(personEmail, basestring)
-        assert isModerator is None or isinstance(isModerator, bool)
-        post_data = {}
-        post_data['roomId'] = roomId
-        if personId:
-            post_data['personId'] = personId
-        elif personEmail:
-            post_data['personEmail'] = personEmail
-        else:
-            error_message = "personId or personEmail must be provided to " \
-                            "add a person to a room.  Neither were provided."
-            raise ciscosparkapiException(error_message)
-        post_data['isModerator'] = isModerator
+        check_type(roomId, basestring, may_be_none=False)
+        check_type(personId, basestring)
+        check_type(personEmail, basestring)
+        check_type(isModerator, bool)
+
+        post_data = dict_from_items_with_values(
+            request_parameters,
+            roomId=roomId,
+            personId=personId,
+            personEmail=personEmail,
+            isModerator=isModerator,
+        )
+
         # API request
-        json_obj = self._session.post('memberships', json=post_data)
+        json_data = self._session.post('memberships', json=post_data)
+
         # Return a Membership object created from the response JSON data
-        return Membership(json_obj)
+        return Membership(json_data)
 
     def get(self, membershipId):
-        """Get details for a membership by ID.
+        """Get details for a membership, by ID.
 
         Args:
-            membershipId(basestring): The membershipId of the membership.
+            membershipId(basestring): The membership ID.
 
         Returns:
-            Membership: With the details of the requested membership.
+            Membership: A Membership object with the details of the requested
+                membership.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(membershipId, basestring)
-        # API request
-        json_obj = self._session.get('memberships/' + membershipId)
-        # Return a Membership object created from the response JSON data
-        return Membership(json_obj)
+        check_type(membershipId, basestring, may_be_none=False)
 
-    def update(self, membershipId, **update_attributes):
-        """Update details for a membership.
+        # API request
+        json_data = self._session.get('memberships/' + membershipId)
+
+        # Return a Membership object created from the response JSON data
+        return Membership(json_data)
+
+    def update(self, membershipId, isModerator=None, **request_parameters):
+        """Updates properties for a membership, by ID.
 
         Args:
-            membershipId(basestring): The membershipId of the membership to
-                be updated.
-            isModerator(bool): If True, sets the person as a moderator for the
-                room. If False, removes the person as a moderator for the room.
+            membershipId(basestring): The membership ID.
+            isModerator(bool): Set to True to make the person a room moderator.
 
         Returns:
-            Membership: With the updated Spark membership details.
+            Membership: A Membership object with the updated Spark membership
+                details.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
-            ciscosparkapiException: If an update attribute is not provided.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(membershipId, basestring)
-        # Process update_attributes keyword arguments
-        if not update_attributes:
-            error_message = "At least one **update_attributes keyword " \
-                            "argument must be specified."
-            raise ciscosparkapiException(error_message)
+        check_type(membershipId, basestring, may_be_none=False)
+        check_type(isModerator, bool)
+
+        put_data = dict_from_items_with_values(
+            request_parameters,
+            isModerator=isModerator,
+        )
+
         # API request
-        json_obj = self._session.put('memberships/' + membershipId,
-                                     json=update_attributes)
+        json_data = self._session.put('memberships/' + membershipId,
+                                     json=put_data)
+
         # Return a Membership object created from the response JSON data
-        return Membership(json_obj)
+        return Membership(json_data)
 
     def delete(self, membershipId):
         """Delete a membership, by ID.
 
         Args:
-            membershipId(basestring): The membershipId of the membership to
-                be deleted.
+            membershipId(basestring): The membership ID.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(membershipId, basestring)
+        check_type(membershipId, basestring)
+
         # API request
         self._session.delete('memberships/' + membershipId)

--- a/ciscosparkapi/api/memberships.py
+++ b/ciscosparkapi/api/memberships.py
@@ -137,7 +137,7 @@ class MembershipsAPI(object):
 
         This method supports Cisco Spark's implementation of RFC5988 Web
         Linking to provide pagination support.  It returns a generator
-        container that incrementally yield all memberships returned by the
+        container that incrementally yields all memberships returned by the
         query.  The generator will automatically request additional 'pages' of
         responses from Spark as needed until all responses have been returned.
         The container makes the generator safe for reuse.  A new API call will
@@ -170,11 +170,11 @@ class MembershipsAPI(object):
         check_type(max, int)
 
         params = dict_from_items_with_values(
-                request_parameters,
-                roomId=roomId,
-                personId=personId,
-                personEmail=personEmail,
-                max=max,
+            request_parameters,
+            roomId=roomId,
+            personId=personId,
+            personEmail=personEmail,
+            max=max,
         )
 
         # API request - get items

--- a/ciscosparkapi/api/messages.py
+++ b/ciscosparkapi/api/messages.py
@@ -3,8 +3,8 @@
 
 Classes:
     Message: Models a Spark 'message' JSON object as a native Python object.
-    MessagesAPI: Wrappers the Cisco Spark Messages-API and exposes the API
-        calls as Python method calls that return native Python objects.
+    MessagesAPI: Wraps the Cisco Spark Messages-API and exposes the APIs as
+        native Python methods that return native Python objects.
 
 """
 
@@ -21,10 +21,11 @@ from past.builtins import basestring
 
 from requests_toolbelt import MultipartEncoder
 
-from ciscosparkapi.exceptions import ciscosparkapiException
 from ciscosparkapi.restsession import RestSession
 from ciscosparkapi.sparkdata import SparkData
 from ciscosparkapi.utils import (
+    check_type,
+    dict_from_items_with_values,
     generator_container,
     is_web_url,
     is_local_file,
@@ -42,10 +43,10 @@ class Message(SparkData):
     """Model a Spark 'message' JSON object as a native Python object."""
 
     def __init__(self, json):
-        """Init a new Message data object from a JSON dictionary or string.
+        """Initialize a Message data object from a dictionary or JSON string.
 
         Args:
-            json(dict, basestring): Input JSON object.
+            json(dict, basestring): Input dictionary or JSON string.
 
         Raises:
             TypeError: If the input object is not a dictionary or string.
@@ -55,64 +56,65 @@ class Message(SparkData):
 
     @property
     def id(self):
-        return self._json['id']
+        """The message's unique ID."""
+        return self._json.get('id')
 
     @property
     def roomId(self):
-        return self._json['roomId']
+        """The ID of the room."""
+        return self._json.get('roomId')
 
     @property
     def roomType(self):
-        return self._json['roomType']
-
-    @property
-    def toPersonId(self):
-        """Optional attribute; returns None if not present."""
-        return self._json.get('toPersonId')
-
-    @property
-    def toPersonEmail(self):
-        """Optional attribute; returns None if not present."""
-        return self._json.get('toPersonEmail')
+        """The type of room (i.e. 'group', 'direct' etc.)."""
+        return self._json.get('roomType')
 
     @property
     def text(self):
-        """Optional attribute; returns None if not present."""
+        """The message, in plain text."""
         return self._json.get('text')
 
     @property
-    def markdown(self):
-        """Optional attribute; returns None if not present."""
-        return self._json.get('markdown')
-
-    @property
     def files(self):
-        """Optional attribute; returns None if not present."""
+        """Files attached to the the message (list of URLs)."""
         return self._json.get('files')
 
     @property
     def personId(self):
-        return self._json['personId']
+        """The person ID of the sender."""
+        return self._json.get('personId')
 
     @property
     def personEmail(self):
-        return self._json['personEmail']
+        """The email address of the sender."""
+        return self._json.get('personEmail')
 
     @property
-    def created(self):
-        return self._json['created']
+    def markdown(self):
+        """The message, in markdown format."""
+        return self._json.get('markdown')
+
+    @property
+    def html(self):
+        """The message, in HTML format."""
+        return self._json.get('html')
 
     @property
     def mentionedPeople(self):
-        """Optional attribute; returns None if not present."""
+        """The list of IDs of people mentioned in the message."""
         return self._json.get('mentionedPeople')
+
+    @property
+    def created(self):
+        """The date and time the message was created."""
+        return self._json.get('created')
 
 
 class MessagesAPI(object):
     """Cisco Spark Messages-API wrapper class.
 
-    Wrappers the Cisco Spark Messages-API and exposes the API calls as Python
-    method calls that return native Python objects.
+    Wraps the Cisco Spark Messages-API and exposes the APIs as native Python
+    methods that return native Python objects.
 
     """
 
@@ -133,12 +135,12 @@ class MessagesAPI(object):
 
     @generator_container
     def list(self, roomId, mentionedPeople=None, before=None,
-             beforeMessage=None, max=None):
-        """List all messages in a room.
+             beforeMessage=None, max=None, **request_parameters):
+        """Lists all messages in a room.
 
-        If present, includes the associated media content attachment for each
-        message.  The list sorts the messages in descending order by creation
-        date.
+        Each message will include content attachments if present.
+
+        The list API sorts the messages in descending order by creation date.
 
         This method supports Cisco Spark's implementation of RFC5988 Web
         Linking to provide pagination support.  It returns a generator
@@ -151,179 +153,170 @@ class MessagesAPI(object):
         container.
 
         Args:
-            roomId(basestring): List messages for the room with roomId.
-            mentionedPeople(basestring): List messages for a person, by
-                personId or me.
-            before(basestring): List messages sent before a date and time,
-                in ISO8601 format
+            roomId(basestring): List messages for a room, by ID.
+            mentionedPeople(basestring): List messages where the caller is
+                mentioned by specifying "me" or the caller `personId`.
+            before(basestring): List messages sent before a date and time, in
+                ISO8601 format.
             beforeMessage(basestring): List messages sent before a message,
-                by message ID
-            max(int): Limit the maximum number of messages returned from the
-                Spark service per request.
+                by ID.
+            max(int): Limit the maximum number of items returned from the Spark
+                service per request.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            GeneratorContainer: When iterated, the GeneratorContainer, yields
-                the messages returned by the Cisco Spark query.
+            GeneratorContainer: A GeneratorContainer which, when iterated,
+                yields the messages returned by the Cisco Spark query.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(roomId, basestring)
-        assert mentionedPeople is None or isinstance(mentionedPeople, list)
-        assert before is None or isinstance(before, basestring)
-        assert beforeMessage is None or isinstance(beforeMessage, basestring)
-        assert max is None or isinstance(max, int)
-        params = {}
-        params['roomId'] = roomId
-        if mentionedPeople:
-            params['mentionedPeople'] = mentionedPeople
-        if before:
-            params['before'] = before
-        if beforeMessage:
-            params['beforeMessage'] = beforeMessage
-        if max:
-            params['max'] = max
+        check_type(roomId, basestring, may_be_none=False)
+        check_type(mentionedPeople, basestring)
+        check_type(before, basestring)
+        check_type(beforeMessage, basestring)
+        check_type(max, int)
+
+        params = dict_from_items_with_values(
+            request_parameters,
+            roomId=roomId,
+            mentionedPeople=mentionedPeople,
+            before=before,
+            beforeMessage=beforeMessage,
+            max=max,
+        )
+
         # API request - get items
         items = self._session.get_items('messages', params=params)
+
         # Yield Message objects created from the returned items JSON objects
         for item in items:
             yield Message(item)
 
     def create(self, roomId=None, toPersonId=None, toPersonEmail=None,
-               text=None, markdown=None, files=None):
-        """Posts a message to a room.
+               text=None, markdown=None, files=None, **request_parameters):
+        """Posts a message, and optionally a attachment, to a room.
 
-        Posts a message, and optionally, a media content attachment, to a room.
-
-        You must specify either a roomId, toPersonId or toPersonEmail when
-        posting a message, and you must supply some message content (text,
-        markdown, files).
+        The files parameter is a list, which accepts multiple values to allow
+        for future expansion, but currently only one file may be included with
+        the message.
 
         Args:
             roomId(basestring): The room ID.
             toPersonId(basestring): The ID of the recipient when sending a
                 private 1:1 message.
-            toPersonEmail(basestring): The email address of the recipient
-                when sending a private 1:1 message.
-            text(basestring): The message, in plain text. If markdown is
+            toPersonEmail(basestring): The email address of the recipient when
+                sending a private 1:1 message.
+            text(basestring): The message, in plain text. If `markdown` is
                 specified this parameter may be optionally used to provide
-                alternate text forUI clients that do not support rich text.
+                alternate text for UI clients that do not support rich text.
             markdown(basestring): The message, in markdown format.
-            files(list): A list containing local paths or URL references for
-                the message attachment(s).  The files attribute currently only
-                takes a list containing one (1) filename or URL as an input.
-                This is a Spark API limitation that may be lifted at a later
-                date.
+            files(list): A list of public URL(s) or local path(s) to files to
+                be posted into the room. Only one file is allowed per message.
+                Uploaded files are automatically converted into a format that
+                all Spark clients can render.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            Message: With the details of the created message.
+            Message: A Message object with the details of the created message.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
-            ciscosparkapiException: If the required arguments are not
-                specified.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
+            ValueError: If the files parameter is a list of length > 1, or if
+                the string in the list (the only element in the list) does not
+                contain a valid URL or path to a local file.
 
         """
-        # Process args
-        assert roomId is None or isinstance(roomId, basestring)
-        assert toPersonId is None or isinstance(toPersonId, basestring)
-        assert toPersonEmail is None or isinstance(toPersonEmail, basestring)
-        assert text is None or isinstance(text, basestring)
-        assert markdown is None or isinstance(markdown, basestring)
-        assert files is None or isinstance(files, list)
-        post_data = {}
-        # Where is message to be posted?
-        if roomId:
-            post_data['roomId'] = roomId
-        elif toPersonId:
-            post_data['toPersonId'] = toPersonId
-        elif toPersonEmail:
-            post_data['toPersonEmail'] = toPersonEmail
-        else:
-            error_message = "You must specify a roomId, toPersonId, or " \
-                            "toPersonEmail to which you want to post a new " \
-                            "message."
-            raise ciscosparkapiException(error_message)
-        # Ensure some message 'content' is provided.
-        if not text and not markdown and not files:
-            error_message = "You must supply some message content (text, " \
-                            "markdown, files) when posting a message."
-            raise ciscosparkapiException(error_message)
-        # Process the content.
-        if text:
-            post_data['text'] = text
-        if markdown:
-            post_data['markdown'] = markdown
-        upload_local_file = False
+        check_type(roomId, basestring)
+        check_type(toPersonId, basestring)
+        check_type(toPersonEmail, basestring)
+        check_type(text, basestring)
+        check_type(markdown, basestring)
+        check_type(files, list)
         if files:
-            if len(files) > 1:
-                error_message = "The files attribute currently only takes a " \
-                                "list containing one (1) filename or URL as " \
-                                "an input.  This is a Spark API limitation " \
-                                "that may be lifted at a later date."
-                raise ciscosparkapiException(error_message)
-            if is_web_url(files[0]):
-                post_data['files'] = files
-            elif is_local_file(files[0]):
-                upload_local_file = True
-                post_data['files'] = open_local_file(files[0])
-            else:
-                error_message = "The provided files argument does not " \
-                                "contain a valid URL or local file path."
-                raise ciscosparkapiException(error_message)
+            if len(files) != 1:
+                raise ValueError("The length of the `files` list is greater "
+                                 "than one (1). The files parameter is a "
+                                 "list, which accepts multiple values to "
+                                 "allow for future expansion, but currently "
+                                 "only one file may be included with the "
+                                 "message.")
+            check_type(files[0], basestring)
+
+        post_data = dict_from_items_with_values(
+            request_parameters,
+            roomId=roomId,
+            toPersonId=toPersonId,
+            toPersonEmail=toPersonEmail,
+            text=text,
+            markdown=markdown,
+            files=files,
+        )
+
         # API request
-        if upload_local_file:
+        if not files or is_web_url(files[0]):
+            # Standard JSON post
+            json_data = self._session.post('messages', json=post_data)
+
+        elif is_local_file(files[0]):
+            # Multipart MIME post
             try:
+                post_data['files'] = open_local_file(files[0])
                 multipart_data = MultipartEncoder(post_data)
                 headers = {'Content-type': multipart_data.content_type}
-                json_obj = self._session.post('messages',
-                                              data=multipart_data,
-                                              headers=headers)
+                json_data = self._session.post('messages',
+                                               headers=headers,
+                                               data=multipart_data)
             finally:
                 post_data['files'].file_object.close()
+
         else:
-            json_obj = self._session.post('messages', json=post_data)
+            raise ValueError("The `files` parameter does not contain a vaild "
+                             "URL or path to a local file.")
+
         # Return a Message object created from the response JSON data
-        return Message(json_obj)
+        return Message(json_data)
 
     def get(self, messageId):
         """Get the details of a message, by ID.
 
         Args:
-            messageId(basestring): The messageId of the message.
+            messageId(basestring): The ID of the message to be retrieved.
 
         Returns:
-            Message: With the details of the requested message.
+            Message: A Message object with the details of the requested
+                message.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(messageId, basestring)
+        check_type(messageId, basestring, may_be_none=False)
+
         # API request
-        json_obj = self._session.get('messages/' + messageId)
+        json_data = self._session.get('messages/' + messageId)
+
         # Return a Message object created from the response JSON data
-        return Message(json_obj)
+        return Message(json_data)
 
     def delete(self, messageId):
         """Delete a message.
 
         Args:
-            messageId(basestring): The messageId of the message to be
-                deleted.
+            messageId(basestring): The ID of the message to be deleted.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(messageId, basestring)
+        check_type(messageId, basestring, may_be_none=False)
+
         # API request
         self._session.delete('messages/' + messageId)

--- a/ciscosparkapi/api/messages.py
+++ b/ciscosparkapi/api/messages.py
@@ -144,7 +144,7 @@ class MessagesAPI(object):
 
         This method supports Cisco Spark's implementation of RFC5988 Web
         Linking to provide pagination support.  It returns a generator
-        container that incrementally yield all messages returned by the
+        container that incrementally yields all messages returned by the
         query.  The generator will automatically request additional 'pages' of
         responses from Spark as needed until all responses have been returned.
         The container makes the generator safe for reuse.  A new API call will

--- a/ciscosparkapi/api/organizations.py
+++ b/ciscosparkapi/api/organizations.py
@@ -52,7 +52,7 @@ class Organization(SparkData):
 
     @property
     def id(self):
-        """The unique id for the Organization."""
+        """The unique ID for the Organization."""
         return self._json.get('id')
 
     @property
@@ -135,7 +135,7 @@ class OrganizationsAPI(object):
             yield Organization(item)
 
     def get(self, orgId):
-        """Get the details of an Organization, by id.
+        """Get the details of an Organization, by ID.
 
         Args:
             orgId(basestring): The ID of the Organization to be retrieved.

--- a/ciscosparkapi/api/organizations.py
+++ b/ciscosparkapi/api/organizations.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
-"""Cisco Spark Organizations API wrapper.
+"""Cisco Spark Organizations-API wrapper.
 
 Classes:
     Organization: Models a Spark Organization JSON object as a native Python
         object.
-    OrganizationsAPI: Wraps the Cisco Spark Organizations API and exposes the
-        API calls as Python method calls that return native Python objects.
+    OrganizationsAPI: Wraps the Cisco Spark Organizations-API and exposes the
+        APIs as native Python methods that return native Python objects.
 
 """
 
@@ -20,9 +20,13 @@ from __future__ import (
 from builtins import *
 from past.builtins import basestring
 
-from ciscosparkapi.utils import generator_container
 from ciscosparkapi.restsession import RestSession
 from ciscosparkapi.sparkdata import SparkData
+from ciscosparkapi.utils import (
+    check_type,
+    dict_from_items_with_values,
+    generator_container,
+)
 
 
 __author__ = "Chris Lunsford"
@@ -35,10 +39,10 @@ class Organization(SparkData):
     """Model a Spark Organization JSON object as a native Python object."""
 
     def __init__(self, json):
-        """Init a new Organization data object from a dict or JSON string.
+        """Init a Organization data object from a dictionary or JSON string.
 
         Args:
-            json(dict, basestring): Input JSON object.
+            json(dict, basestring): Input dictionary or JSON string.
 
         Raises:
             TypeError: If the input object is not a dictionary or string.
@@ -58,15 +62,15 @@ class Organization(SparkData):
 
     @property
     def created(self):
-        """The date and time the Organization was created."""
+        """Creation date and time in ISO8601 format."""
         return self._json.get('created')
 
 
 class OrganizationsAPI(object):
-    """Cisco Spark Organizations API wrapper.
+    """Cisco Spark Organizations-API wrapper.
 
-    Wraps the Cisco Spark Organizations API and exposes the API calls as Python
-    method calls that return native Python objects.
+    Wraps the Cisco Spark Organizations-API and exposes the APIs as native
+    Python methods that return native Python objects.
 
     """
 
@@ -78,15 +82,17 @@ class OrganizationsAPI(object):
                 API calls to the Cisco Spark service.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
 
         """
-        assert isinstance(session, RestSession)
+        check_type(session, RestSession, may_be_none=False)
+
         super(OrganizationsAPI, self).__init__()
+
         self._session = session
 
     @generator_container
-    def list(self, max=None):
+    def list(self, max=None,  **request_parameters):
         """List Organizations.
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -100,26 +106,30 @@ class OrganizationsAPI(object):
         container.
 
         Args:
-            max(int): Limits the maximum number of entries returned from the
-                Spark service per request (page size; requesting additional
-                pages is handled automatically).
+            max(int): Limit the maximum number of items returned from the Spark
+                service per request.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            GeneratorContainer: When iterated, the GeneratorContainer, yields
-                the objects returned from the Cisco Spark query.
+            GeneratorContainer: A GeneratorContainer which, when iterated,
+                yields the organizations returned by the Cisco Spark query.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert max is None or isinstance(max, int)
-        params = {}
-        if max:
-            params['max'] = max
+        check_type(max, int)
+
+        params = dict_from_items_with_values(
+            request_parameters,
+            max=max,
+        )
+
         # API request - get items
         items = self._session.get_items('organizations', params=params)
+
         # Yield Organization objects created from the returned JSON objects
         for item in items:
             yield Organization(item)
@@ -128,19 +138,21 @@ class OrganizationsAPI(object):
         """Get the details of an Organization, by id.
 
         Args:
-            orgId(basestring): The id of the Organization.
+            orgId(basestring): The ID of the Organization to be retrieved.
 
         Returns:
-            Organization: With the details of the requested Organization.
+            Organization: An Organization object with the details of the
+                requested organization.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(orgId, basestring)
+        check_type(orgId, basestring, may_be_none=False)
+
         # API request
-        json_obj = self._session.get('organizations/' + orgId)
+        json_data = self._session.get('organizations/' + orgId)
+
         # Return a Organization object created from the returned JSON object
-        return Organization(json_obj)
+        return Organization(json_data)

--- a/ciscosparkapi/api/organizations.py
+++ b/ciscosparkapi/api/organizations.py
@@ -92,7 +92,7 @@ class OrganizationsAPI(object):
         self._session = session
 
     @generator_container
-    def list(self, max=None,  **request_parameters):
+    def list(self, max=None, **request_parameters):
         """List Organizations.
 
         This method supports Cisco Spark's implementation of RFC5988 Web

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -19,13 +19,13 @@ from __future__ import (
 from builtins import *
 from past.builtins import basestring
 
+from ciscosparkapi.restsession import RestSession
+from ciscosparkapi.sparkdata import SparkData
 from ciscosparkapi.utils import (
     check_type,
     dict_from_items_with_values,
     generator_container,
 )
-from ciscosparkapi.restsession import RestSession
-from ciscosparkapi.sparkdata import SparkData
 
 
 __author__ = "Chris Lunsford"
@@ -177,8 +177,8 @@ class PeopleAPI(object):
             id(basestring): List people by ID. Accepts up to 85 person IDs
                 separated by commas.
             orgId(basestring): The organization id.
-            max(int): Limits the maximum number of people returned from the
-                Spark service per request.
+            max(int): Limit the maximum number of items returned from the Spark
+                service per request.
             **request_parameters: Additional request parameters (provides
                 support for parameters that may be added in the future).
 
@@ -271,6 +271,28 @@ class PeopleAPI(object):
         # Return a Person object created from the returned JSON object
         return Person(json_data)
 
+    def get(self, personId):
+        """Get a person's details, by ID.
+
+        Args:
+            personId(basestring): The ID of the person to be retrieved.
+
+        Returns:
+            Person: A Person object with the details of the requested person.
+
+        Raises:
+            TypeError: If the parameter types are incorrect.
+            SparkApiError: If the Cisco Spark cloud returns an error.
+
+        """
+        check_type(personId, basestring, may_be_none=False)
+
+        # API request
+        json_data = self._session.get('people/' + personId)
+
+        # Return a Person object created from the response JSON data
+        return Person(json_data)
+
     def update(self, personId, emails=None, displayName=None, firstName=None,
                lastName=None, avatar=None, orgId=None, roles=None,
                licenses=None, **request_parameters):
@@ -286,7 +308,7 @@ class PeopleAPI(object):
         unchanged values.
 
         Args:
-            personId(basestring): The 'id' of the person to be updated.
+            personId(basestring): The person ID.
             emails(list): Email address(es) of the person (list of strings).
             displayName(basestring): Full name of the person.
             firstName(basestring): First name of the person.
@@ -335,28 +357,6 @@ class PeopleAPI(object):
         json_data = self._session.put('people/' + personId, json=put_data)
 
         # Return a Person object created from the returned JSON object
-        return Person(json_data)
-
-    def get(self, personId):
-        """Get a person's details, by ID.
-
-        Args:
-            personId(basestring): The ID of the person to be retrieved.
-
-        Returns:
-            Person: A Person object with the details of the requested person.
-
-        Raises:
-            TypeError: If the parameter types are incorrect.
-            SparkApiError: If the Cisco Spark cloud returns an error.
-
-        """
-        check_type(personId, basestring, may_be_none=False)
-
-        # API request
-        json_data = self._session.get('people/' + personId)
-
-        # Return a Person object created from the response JSON data
         return Person(json_data)
 
     def delete(self, personId):

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -35,16 +35,21 @@ class Person(SparkData):
     """Model a Spark 'person' JSON object as a native Python object."""
 
     def __init__(self, json):
-        """Init a new Person data object from a JSON dictionary or string.
+        """Initialize a Person data object from a dictionary or JSON string.
 
         Args:
-            json(dict, basestring): Input JSON object.
+            json(dict, basestring): Input dictionary or JSON string.
 
         Raises:
             TypeError: If the input object is not a dictionary or string.
 
         """
         super(Person, self).__init__(json)
+
+    @property
+    def type(self):
+        """The type of object returned by Cisco Spark (should be `person`)."""
+        return self._json.get('type')
 
     @property
     def id(self):
@@ -66,6 +71,11 @@ class Person(SparkData):
     def displayName(self):
         """Full name of the person."""
         return self._json.get('displayName')
+
+    @property
+    def nickName(self):
+        """'Nick name' or preferred short name of the person."""
+        return self._json.get('nickName')
 
     @property
     def firstName(self):
@@ -112,17 +122,27 @@ class Person(SparkData):
         """The date and time of the person's last activity."""
         return self._json.get('lastActivity')
 
+    @property
+    def invitePending(self):
+        """Person has been sent an invite, but hasn't responded."""
+        return self._json.get('invitePending')
+
+    @property
+    def loginEnabled(self):
+        """Person is allowed to login."""
+        return self._json.get('loginEnabled')
+
 
 class PeopleAPI(object):
     """Cisco Spark People-API wrapper class.
 
-    Wrappers the Cisco Spark People-API and exposes the API calls as Python
-    method calls that return native Python objects.
+    Wraps the Cisco Spark People-API and exposes the APIs as native Python
+    methods that return native Python objects.
 
     """
 
     def __init__(self, session):
-        """Init a new PeopleAPI object with the provided RestSession.
+        """Initialize a new PeopleAPI object with the provided RestSession.
 
         Args:
             session(RestSession): The RESTful session object to be used for

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -137,7 +137,7 @@ class PeopleAPI(object):
         self._session = session
 
     @generator_container
-    def list(self, email=None, displayName=None, orgId=None, max=None):
+    def list(self, email=None, displayName=None, orgId=None, id=None, max=None):
         """List people
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -154,6 +154,7 @@ class PeopleAPI(object):
             email(basestring): The e-mail address of the person to be found.
             displayName(basestring): The complete or beginning portion of
                 the displayName to be searched.
+            id(basestring): List people by ID. Accepts up to 85 person IDs separated by commas.
             orgId(basestring): The organization id.
             max(int): Limits the maximum number of people returned from the
                 Spark service per request.
@@ -171,16 +172,20 @@ class PeopleAPI(object):
         assert email is None or isinstance(email, basestring)
         assert displayName is None or isinstance(displayName, basestring)
         assert orgId is None or isinstance(orgId, basestring)
+        assert id is None or isinstance(id, basestring)
         assert max is None or isinstance(max, int)
         params = {}
-        if email:
-            params['email'] = email
-        elif displayName:
-            params['displayName'] = displayName
-        if orgId:
-            params["orgId"] = orgId
-        if max:
-            params['max'] = max
+        if id:
+            params["id"] = id
+        else:
+            if email:
+                params['email'] = email
+            elif displayName:
+                params['displayName'] = displayName
+            if orgId:
+                params["orgId"] = orgId
+            if max:
+                params['max'] = max
         # API request - get items
         items = self._session.get_items('people', params=params)
         # Yield Person objects created from the returned items JSON objects

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -338,10 +338,10 @@ class PeopleAPI(object):
         return Person(json_data)
 
     def get(self, personId):
-        """Get person details, by personId.
+        """Get a person's details, by ID.
 
         Args:
-            personId(basestring): The 'id' of the person to be retrieved.
+            personId(basestring): The ID of the person to be retrieved.
 
         Returns:
             Person: A Person object with the details of the requested person.

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -176,7 +176,7 @@ class PeopleAPI(object):
                 the displayName to be searched.
             id(basestring): List people by ID. Accepts up to 85 person IDs
                 separated by commas.
-            orgId(basestring): The organization id.
+            orgId(basestring): The organization ID.
             max(int): Limit the maximum number of items returned from the Spark
                 service per request.
             **request_parameters: Additional request parameters (provides
@@ -365,7 +365,7 @@ class PeopleAPI(object):
         Only an admin can remove a person.
 
         Args:
-            personId(basestring): The 'id' of the person to be deleted.
+            personId(basestring): The ID of the person to be deleted.
 
         Raises:
             AssertionError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -157,7 +157,7 @@ class PeopleAPI(object):
 
     @generator_container
     def list(self, email=None, displayName=None, id=None, orgId=None, max=None,
-             **query_params):
+             **request_parameters):
         """List people
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -179,8 +179,8 @@ class PeopleAPI(object):
             orgId(basestring): The organization id.
             max(int): Limits the maximum number of people returned from the
                 Spark service per request.
-            **query_params: Additional query parameters (provides support for
-                query parameters that may be added in the future).
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
@@ -198,7 +198,7 @@ class PeopleAPI(object):
         check_type(max, int)
 
         params = dict_from_items_with_values(
-                query_params,
+                request_parameters,
                 id=id,
                 email=email,
                 displayName=displayName,
@@ -215,7 +215,7 @@ class PeopleAPI(object):
 
     def create(self, emails, displayName=None, firstName=None, lastName=None,
                avatar=None, orgId=None, roles=None, licenses=None,
-               **person_attributes):
+               **request_parameters):
         """Create a new user account for a given organization
 
         Only an admin can create a new user account.
@@ -233,8 +233,8 @@ class PeopleAPI(object):
             licenses(list): Licenses allocated to the person (list of
                 strings - containing the license IDs to be allocated to the
                 person).
-            **person_attributes: Additional person attributes (provides support
-                for attributes that may be added in the future).
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
             Person: A Person object with the details of the created person.
@@ -254,7 +254,7 @@ class PeopleAPI(object):
         check_type(licenses, list)
 
         post_data = dict_from_items_with_values(
-                person_attributes,
+                request_parameters,
                 emails=emails,
                 displayName=displayName,
                 firstName=firstName,
@@ -273,7 +273,7 @@ class PeopleAPI(object):
 
     def update(self, personId, emails=None, displayName=None, firstName=None,
                lastName=None, avatar=None, orgId=None, roles=None,
-               licenses=None, **person_attributes):
+               licenses=None, **request_parameters):
         """Update details for a person, by ID.
 
         Only an admin can update a person's details.
@@ -299,8 +299,8 @@ class PeopleAPI(object):
             licenses(list): Licenses allocated to the person (list of
                 strings - containing the license IDs to be allocated to the
                 person).
-            **person_attributes: Additional person attributes (provides support
-                for attributes that may be added in the future).
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
             Person: A Person object with the updated details.
@@ -320,7 +320,7 @@ class PeopleAPI(object):
         check_type(licenses, list)
 
         put_data = dict_from_items_with_values(
-                person_attributes,
+                request_parameters,
                 emails=emails,
                 displayName=displayName,
                 firstName=firstName,

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -137,7 +137,7 @@ class PeopleAPI(object):
         self._session = session
 
     @generator_container
-    def list(self, email=None, displayName=None, max=None):
+    def list(self, email=None, displayName=None, orgId=None, max=None):
         """List people
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -154,6 +154,7 @@ class PeopleAPI(object):
             email(basestring): The e-mail address of the person to be found.
             displayName(basestring): The complete or beginning portion of
                 the displayName to be searched.
+            orgId(basestring): The organization id.
             max(int): Limits the maximum number of people returned from the
                 Spark service per request.
 
@@ -169,12 +170,15 @@ class PeopleAPI(object):
         # Process args
         assert email is None or isinstance(email, basestring)
         assert displayName is None or isinstance(displayName, basestring)
+        assert orgId is None or isinstance(orgId, basestring)
         assert max is None or isinstance(max, int)
         params = {}
         if email:
             params['email'] = email
         elif displayName:
             params['displayName'] = displayName
+        if orgId:
+            params["orgId"] = orgId
         if max:
             params['max'] = max
         # API request - get items

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -268,7 +268,7 @@ class PeopleAPI(object):
         # API request
         json_data = self._session.post('people', json=post_data)
 
-        # Return a Room object created from the returned JSON object
+        # Return a Person object created from the returned JSON object
         return Person(json_data)
 
     def update(self, personId, emails=None, displayName=None, firstName=None,

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -177,15 +177,14 @@ class PeopleAPI(object):
         params = {}
         if id:
             params["id"] = id
-        else:
-            if email:
+        elif email:
                 params['email'] = email
-            elif displayName:
-                params['displayName'] = displayName
-            if orgId:
-                params["orgId"] = orgId
-            if max:
-                params['max'] = max
+        elif displayName:
+            params['displayName'] = displayName
+        if orgId:
+            params["orgId"] = orgId
+        if max:
+            params['max'] = max
         # Process query_param keyword arguments
         if query_params:
             params.update(query_params)

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -198,12 +198,12 @@ class PeopleAPI(object):
         check_type(max, int)
 
         params = dict_from_items_with_values(
-                request_parameters,
-                id=id,
-                email=email,
-                displayName=displayName,
-                orgId=orgId,
-                max=max,
+            request_parameters,
+            id=id,
+            email=email,
+            displayName=displayName,
+            orgId=orgId,
+            max=max,
         )
 
         # API request - get items

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -254,15 +254,15 @@ class PeopleAPI(object):
         check_type(licenses, list)
 
         post_data = dict_from_items_with_values(
-                request_parameters,
-                emails=emails,
-                displayName=displayName,
-                firstName=firstName,
-                lastName=lastName,
-                avatar=avatar,
-                orgId=orgId,
-                roles=roles,
-                licenses=licenses,
+            request_parameters,
+            emails=emails,
+            displayName=displayName,
+            firstName=firstName,
+            lastName=lastName,
+            avatar=avatar,
+            orgId=orgId,
+            roles=roles,
+            licenses=licenses,
         )
 
         # API request
@@ -342,15 +342,15 @@ class PeopleAPI(object):
         check_type(licenses, list)
 
         put_data = dict_from_items_with_values(
-                request_parameters,
-                emails=emails,
-                displayName=displayName,
-                firstName=firstName,
-                lastName=lastName,
-                avatar=avatar,
-                orgId=orgId,
-                roles=roles,
-                licenses=licenses,
+            request_parameters,
+            emails=emails,
+            displayName=displayName,
+            firstName=firstName,
+            lastName=lastName,
+            avatar=avatar,
+            orgId=orgId,
+            roles=roles,
+            licenses=licenses,
         )
 
         # API request

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -137,7 +137,7 @@ class PeopleAPI(object):
         self._session = session
 
     @generator_container
-    def list(self, email=None, displayName=None, orgId=None, id=None, max=None):
+    def list(self, email=None, displayName=None, orgId=None, id=None, max=None, **query_params):
         """List people
 
         This method supports Cisco Spark's implementation of RFC5988 Web
@@ -186,6 +186,9 @@ class PeopleAPI(object):
                 params["orgId"] = orgId
             if max:
                 params['max'] = max
+        # Process query_param keyword arguments
+        if query_params:
+            params.update(query_params)
         # API request - get items
         items = self._session.get_items('people', params=params)
         # Yield Person objects created from the returned items JSON objects

--- a/ciscosparkapi/api/roles.py
+++ b/ciscosparkapi/api/roles.py
@@ -51,7 +51,7 @@ class Role(SparkData):
 
     @property
     def id(self):
-        """The unique id for the Role."""
+        """The unique ID for the Role."""
         return self._json.get('id')
 
     @property

--- a/ciscosparkapi/api/roles.py
+++ b/ciscosparkapi/api/roles.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-"""Cisco Spark Roles API wrapper.
+"""Cisco Spark Roles-API wrapper.
 
 Classes:
     Role: Models a Spark Role JSON object as a native Python object.
-    RolesAPI: Wraps the Cisco Spark Roles API and exposes the
-        API calls as Python method calls that return native Python objects.
+    RolesAPI: Wraps the Cisco Spark Roles-API and exposes the APIs as native
+        Python methods that return native Python objects.
 
 """
 
@@ -19,9 +19,13 @@ from __future__ import (
 from builtins import *
 from past.builtins import basestring
 
-from ciscosparkapi.utils import generator_container
 from ciscosparkapi.restsession import RestSession
 from ciscosparkapi.sparkdata import SparkData
+from ciscosparkapi.utils import (
+    check_type,
+    dict_from_items_with_values,
+    generator_container,
+)
 
 
 __author__ = "Chris Lunsford"
@@ -34,10 +38,10 @@ class Role(SparkData):
     """Model a Spark Role JSON object as a native Python object."""
 
     def __init__(self, json):
-        """Init a new Role data object from a dict or JSON string.
+        """Initialize a new Role data object from a dictionary or JSON string.
 
         Args:
-            json(dict, basestring): Input JSON object.
+            json(dict, basestring): Input dictionary or JSON string.
 
         Raises:
             TypeError: If the input object is not a dictionary or string.
@@ -57,31 +61,33 @@ class Role(SparkData):
 
 
 class RolesAPI(object):
-    """Cisco Spark Roles API wrapper.
+    """Cisco Spark Roles-API wrapper.
 
-    Wraps the Cisco Spark Roles API and exposes the API calls as Python
-    method calls that return native Python objects.
+    Wraps the Cisco Spark Roles-API and exposes the APIs as native Python
+    methods that return native Python objects.
 
     """
 
     def __init__(self, session):
-        """Init a new RolesAPI object with the provided RestSession.
+        """Initialize a new RolesAPI object with the provided RestSession.
 
         Args:
             session(RestSession): The RESTful session object to be used for
                 API calls to the Cisco Spark service.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
 
         """
-        assert isinstance(session, RestSession)
+        check_type(session, RestSession, may_be_none=False)
+
         super(RolesAPI, self).__init__()
+
         self._session = session
 
     @generator_container
-    def list(self, max=None):
-        """List Roles.
+    def list(self, max=None, **request_parameters):
+        """List all roles.
 
         This method supports Cisco Spark's implementation of RFC5988 Web
         Linking to provide pagination support.  It returns a generator
@@ -94,47 +100,52 @@ class RolesAPI(object):
         container.
 
         Args:
-            max(int): Limits the maximum number of entries returned from the
-                Spark service per request (page size; requesting additional
-                pages is handled automatically).
+            max(int): Limit the maximum number of items returned from the Spark
+                service per request.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            GeneratorContainer: When iterated, the GeneratorContainer, yields
-                the objects returned from the Cisco Spark query.
+            GeneratorContainer: A GeneratorContainer which, when iterated,
+                yields the roles returned by the Cisco Spark query.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert max is None or isinstance(max, int)
-        params = {}
-        if max:
-            params['max'] = max
+        check_type(max, int)
+
+        params = dict_from_items_with_values(
+            request_parameters,
+            max=max,
+        )
+
         # API request - get items
         items = self._session.get_items('roles', params=params)
+
         # Yield Role objects created from the returned JSON objects
         for item in items:
             yield Role(item)
 
     def get(self, roleId):
-        """Get the details of a Role, by id.
+        """Get the details of a Role, by ID.
 
         Args:
-            roleId(basestring): The id of the Role.
+            roleId(basestring): The ID of the Role to be retrieved.
 
         Returns:
-            Role: With the details of the requested Role.
+            Role: A Role object with the details of the requested Role.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(roleId, basestring)
+        check_type(roleId, basestring, may_be_none=False)
+
         # API request
-        json_obj = self._session.get('roles/' + roleId)
+        json_data = self._session.get('roles/' + roleId)
+
         # Return a Role object created from the returned JSON object
-        return Role(json_obj)
+        return Role(json_data)

--- a/ciscosparkapi/api/rooms.py
+++ b/ciscosparkapi/api/rooms.py
@@ -199,9 +199,9 @@ class RoomsAPI(object):
         check_type(teamId, basestring)
 
         post_data = dict_from_items_with_values(
-                request_parameters,
-                title=title,
-                teamId=teamId,
+            request_parameters,
+            title=title,
+            teamId=teamId,
         )
 
         # API request
@@ -253,8 +253,8 @@ class RoomsAPI(object):
         check_type(roomId, basestring)
 
         put_data = dict_from_items_with_values(
-                request_parameters,
-                title=title,
+            request_parameters,
+            title=title,
         )
 
         # API request

--- a/ciscosparkapi/api/rooms.py
+++ b/ciscosparkapi/api/rooms.py
@@ -19,14 +19,13 @@ from __future__ import (
 from builtins import *
 from past.builtins import basestring
 
-from ciscosparkapi.exceptions import ciscosparkapiException
+from ciscosparkapi.restsession import RestSession
+from ciscosparkapi.sparkdata import SparkData
 from ciscosparkapi.utils import (
     check_type,
     dict_from_items_with_values,
     generator_container,
 )
-from ciscosparkapi.restsession import RestSession
-from ciscosparkapi.sparkdata import SparkData
 
 
 __author__ = "Chris Lunsford"
@@ -142,8 +141,8 @@ class RoomsAPI(object):
             sortBy(basestring): Sort results by room ID (`id`), most recent
                 activity (`lastactivity`), or most recently created
                 (`created`).
-            max(int): Limit the maximum number of rooms in the response from
-                the Spark service.
+            max(int): Limit the maximum number of items returned from the Spark
+                service per request.
             **request_parameters: Additional request parameters (provides
                 support for parameters that may be added in the future).
 
@@ -211,11 +210,33 @@ class RoomsAPI(object):
         # Return a Room object created from the response JSON data
         return Room(json_data)
 
+    def get(self, roomId):
+        """Get the details of a room, by ID.
+
+        Args:
+            roomId(basestring): The ID of the room to be retrieved.
+
+        Returns:
+            Room: A Room object with the details of the requested room.
+
+        Raises:
+            TypeError: If the parameter types are incorrect.
+            SparkApiError: If the Cisco Spark cloud returns an error.
+
+        """
+        check_type(roomId, basestring, may_be_none=False)
+
+        # API request
+        json_data = self._session.get('rooms/' + roomId)
+
+        # Return a Room object created from the response JSON data
+        return Room(json_data)
+
     def update(self, roomId, title=None, **request_parameters):
         """Update details for a room, by ID.
 
         Args:
-            roomId(basestring): The ID of the room to be updated.
+            roomId(basestring): The room ID.
             title(basestring): A user-friendly name for the room.
             **request_parameters: Additional request parameters (provides
                 support for parameters that may be added in the future).
@@ -238,28 +259,6 @@ class RoomsAPI(object):
 
         # API request
         json_data = self._session.put('rooms/' + roomId, json=put_data)
-
-        # Return a Room object created from the response JSON data
-        return Room(json_data)
-
-    def get(self, roomId):
-        """Get the details of a room, by ID.
-
-        Args:
-            roomId(basestring): The ID of the room to be retrieved.
-
-        Returns:
-            Room: A Room object with the details of the requested room.
-
-        Raises:
-            TypeError: If the parameter types are incorrect.
-            SparkApiError: If the Cisco Spark cloud returns an error.
-
-        """
-        check_type(roomId, basestring, may_be_none=False)
-
-        # API request
-        json_data = self._session.get('rooms/' + roomId)
 
         # Return a Room object created from the response JSON data
         return Room(json_data)

--- a/ciscosparkapi/api/rooms.py
+++ b/ciscosparkapi/api/rooms.py
@@ -3,8 +3,8 @@
 
 Classes:
     Room: Models a Spark 'room' JSON object as a native Python object.
-    RoomsAPI: Wrappers the Cisco Spark Rooms-API and exposes the API calls as
-        Python method calls that return native Python objects.
+    RoomsAPI: Wraps the Cisco Spark Rooms-API and exposes the APIs as native
+        Python methods that return native Python objects.
 
 """
 
@@ -35,10 +35,10 @@ class Room(SparkData):
     """Model a Spark 'room' JSON object as a native Python object."""
 
     def __init__(self, json):
-        """Init a new Room data object from a JSON dictionary or string.
+        """Initialize a Room data object from a dictionary or JSON string.
 
         Args:
-            json(dict, basestring): Input JSON object.
+            json(dict, basestring): Input dictionary or JSON string.
 
         Raises:
             TypeError: If the input object is not a dictionary or string.
@@ -48,42 +48,43 @@ class Room(SparkData):
 
     @property
     def id(self):
-        return self._json['id']
+        """The rooms's unique ID."""
+        return self._json.get('id')
 
     @property
     def title(self):
-        return self._json['title']
+        """A user-friendly name for the room."""
+        return self._json.get('title')
 
     @property
     def type(self):
-        return self._json['type']
+        """The type of room (i.e. 'group', 'direct' etc.)."""
+        return self._json.get('type')
 
     @property
     def isLocked(self):
-        return self._json['isLocked']
+        """Whether or not the room is locked and controled by moderator(s)."""
+        return self._json.get('isLocked')
 
     @property
     def lastActivity(self):
-        return self._json['lastActivity']
+        """The date and time when the room was last active."""
+        return self._json.get('lastActivity')
 
     @property
     def created(self):
-        return self._json['created']
+        """The date and time when the room was created."""
+        return self._json.get('created')
 
     @property
     def creatorId(self):
-        return self._json['creatorId']
+        """The ID of the person who created the room."""
+        return self._json.get('creatorId')
 
     @property
     def teamId(self):
-        """Return the room teamId, if it exists, otherwise return None.
-
-        teamId is an 'optional' attribute that only exists for Spark rooms that
-        are associated with a Spark Team.  To simplify use, rather than
-        requiring use of try/catch statements or hasattr() calls, we simply
-        return None if a room does not have a teamId attribute.
-        """
-        return self._json.get('teamId', None)
+        """The ID for the team with which this room is associated."""
+        return self._json.get('teamId')
 
 
 class RoomsAPI(object):

--- a/ciscosparkapi/api/rooms.py
+++ b/ciscosparkapi/api/rooms.py
@@ -20,7 +20,11 @@ from builtins import *
 from past.builtins import basestring
 
 from ciscosparkapi.exceptions import ciscosparkapiException
-from ciscosparkapi.utils import generator_container
+from ciscosparkapi.utils import (
+    check_type,
+    dict_from_items_with_values,
+    generator_container,
+)
 from ciscosparkapi.restsession import RestSession
 from ciscosparkapi.sparkdata import SparkData
 
@@ -90,28 +94,31 @@ class Room(SparkData):
 class RoomsAPI(object):
     """Cisco Spark Rooms-API wrapper class.
 
-    Wrappers the Cisco Spark Rooms-API and exposes the API calls as Python
-    method calls that return native Python objects.
+    Wraps the Cisco Spark Rooms-API and exposes the APIs as native Python
+    methods that return native Python objects.
 
     """
 
     def __init__(self, session):
-        """Init a new RoomsAPI object with the provided RestSession.
+        """Initialize a new RoomsAPI object with the provided RestSession.
 
         Args:
             session(RestSession): The RESTful session object to be used for
                 API calls to the Cisco Spark service.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
 
         """
-        assert isinstance(session, RestSession)
+        check_type(session, RestSession, may_be_none=False)
+
         super(RoomsAPI, self).__init__()
+
         self._session = session
 
     @generator_container
-    def list(self, max=None, **query_params):
+    def list(self, teamId=None, type=None, sortBy=None, max=None,
+             **request_parameters):
         """List rooms.
 
         By default, lists rooms to which the authenticated user belongs.
@@ -127,38 +134,49 @@ class RoomsAPI(object):
         container.
 
         Args:
-            max(int): Limits the maximum number of rooms returned from the
-                Spark service per request.
             teamId(basestring): Limit the rooms to those associated with a
-                team.
-            type(basestring):
-                'direct': returns all 1-to-1 rooms.
-                'group': returns all group rooms.
+                team, by ID.
+            type(basestring): 'direct' returns all 1-to-1 rooms. `group`
+                returns all group rooms. If not specified or values not
+                matched, will return all room types.
+            sortBy(basestring): Sort results by room ID (`id`), most recent
+                activity (`lastactivity`), or most recently created
+                (`created`).
+            max(int): Limit the maximum number of rooms in the response from
+                the Spark service.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            GeneratorContainer: When iterated, the GeneratorContainer, yields
-                the rooms returned from the Cisco Spark query.
+            GeneratorContainer: A GeneratorContainer which, when iterated,
+                yields the rooms returned by the Cisco Spark query.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert max is None or isinstance(max, int)
-        params = {}
-        if max:
-            params['max'] = max
-        # Process query_param keyword arguments
-        if query_params:
-            params.update(query_params)
+        check_type(teamId, basestring)
+        check_type(type, basestring)
+        check_type(sortBy, basestring)
+        check_type(max, int)
+
+        params = dict_from_items_with_values(
+                request_parameters,
+                teamId=teamId,
+                type=type,
+                sortBy=sortBy,
+                max=max,
+        )
+
         # API request - get items
         items = self._session.get_items('rooms', params=params)
+
         # Yield Room objects created from the returned items JSON objects
         for item in items:
             yield Room(item)
 
-    def create(self, title, teamId=None):
+    def create(self, title, teamId=None, **request_parameters):
         """Create a room.
 
         The authenticated user is automatically added as a member of the room.
@@ -167,88 +185,97 @@ class RoomsAPI(object):
             title(basestring): A user-friendly name for the room.
             teamId(basestring): The team ID with which this room is
                 associated.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
 
         Returns:
-            Room: With the details of the created room.
+            Room: A Room with the details of the created room.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(title, basestring)
-        assert teamId is None or isinstance(teamId, basestring)
-        post_data = {}
-        post_data['title'] = title
-        if teamId:
-            post_data['teamId'] = teamId
+        check_type(title, basestring)
+        check_type(teamId, basestring)
+
+        post_data = dict_from_items_with_values(
+                request_parameters,
+                title=title,
+                teamId=teamId,
+        )
+
         # API request
-        json_obj = self._session.post('rooms', json=post_data)
+        json_data = self._session.post('rooms', json=post_data)
+
         # Return a Room object created from the response JSON data
-        return Room(json_obj)
+        return Room(json_data)
+
+    def update(self, roomId, title=None, **request_parameters):
+        """Update details for a room, by ID.
+
+        Args:
+            roomId(basestring): The ID of the room to be updated.
+            title(basestring): A user-friendly name for the room.
+            **request_parameters: Additional request parameters (provides
+                support for parameters that may be added in the future).
+
+        Returns:
+            Room: A Room object with the updated Spark room details.
+
+        Raises:
+            TypeError: If the parameter types are incorrect.
+            SparkApiError: If the Cisco Spark cloud returns an error.
+
+        """
+        check_type(roomId, basestring, may_be_none=False)
+        check_type(roomId, basestring)
+
+        put_data = dict_from_items_with_values(
+                request_parameters,
+                title=title,
+        )
+
+        # API request
+        json_data = self._session.put('rooms/' + roomId, json=put_data)
+
+        # Return a Room object created from the response JSON data
+        return Room(json_data)
 
     def get(self, roomId):
         """Get the details of a room, by ID.
 
         Args:
-            roomId(basestring): The roomId of the room.
+            roomId(basestring): The ID of the room to be retrieved.
 
         Returns:
-            Room: With the details of the requested room.
+            Room: A Room object with the details of the requested room.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(roomId, basestring)
+        check_type(roomId, basestring, may_be_none=False)
+
         # API request
-        json_obj = self._session.get('rooms/' + roomId)
+        json_data = self._session.get('rooms/' + roomId)
+
         # Return a Room object created from the response JSON data
-        return Room(json_obj)
-
-    def update(self, roomId, **update_attributes):
-        """Update details for a room.
-
-        Args:
-            roomId(basestring): The roomId of the room to be updated.
-            title(basestring): A user-friendly name for the room.
-
-        Returns:
-            Room: With the updated Spark room details.
-
-        Raises:
-            AssertionError: If the parameter types are incorrect.
-            ciscosparkapiException: If an update attribute is not provided.
-            SparkApiError: If the Cisco Spark cloud returns an error.
-
-        """
-        # Process args
-        assert isinstance(roomId, basestring)
-        # Process update_attributes keyword arguments
-        if not update_attributes:
-            error_message = "At least one **update_attributes keyword " \
-                            "argument must be specified."
-            raise ciscosparkapiException(error_message)
-        # API request
-        json_obj = self._session.put('rooms/' + roomId, json=update_attributes)
-        # Return a Room object created from the response JSON data
-        return Room(json_obj)
+        return Room(json_data)
 
     def delete(self, roomId):
         """Delete a room.
 
         Args:
-            roomId(basestring): The roomId of the room to be deleted.
+            roomId(basestring): The ID of the room to be deleted.
 
         Raises:
-            AssertionError: If the parameter types are incorrect.
+            TypeError: If the parameter types are incorrect.
             SparkApiError: If the Cisco Spark cloud returns an error.
 
         """
-        # Process args
-        assert isinstance(roomId, basestring)
+        check_type(roomId, basestring, may_be_none=False)
+
         # API request
         self._session.delete('rooms/' + roomId)

--- a/ciscosparkapi/api/rooms.py
+++ b/ciscosparkapi/api/rooms.py
@@ -124,7 +124,7 @@ class RoomsAPI(object):
 
         This method supports Cisco Spark's implementation of RFC5988 Web
         Linking to provide pagination support.  It returns a generator
-        container that incrementally yield all rooms returned by the
+        container that incrementally yields all rooms returned by the
         query.  The generator will automatically request additional 'pages' of
         responses from Spark as needed until all responses have been returned.
         The container makes the generator safe for reuse.  A new API call will
@@ -161,11 +161,11 @@ class RoomsAPI(object):
         check_type(max, int)
 
         params = dict_from_items_with_values(
-                request_parameters,
-                teamId=teamId,
-                type=type,
-                sortBy=sortBy,
-                max=max,
+            request_parameters,
+            teamId=teamId,
+            type=type,
+            sortBy=sortBy,
+            max=max,
         )
 
         # API request - get items

--- a/ciscosparkapi/api/teams.py
+++ b/ciscosparkapi/api/teams.py
@@ -138,7 +138,7 @@ class TeamsAPI(object):
         for item in items:
             yield Team(item)
 
-    def create(self, name,  **request_parameters):
+    def create(self, name, **request_parameters):
         """Create a team.
 
         The authenticated user is automatically added as a member of the team.

--- a/ciscosparkapi/exceptions.py
+++ b/ciscosparkapi/exceptions.py
@@ -68,11 +68,11 @@ def response_to_string(response):
     # Prepare request components
     req = textwrap.fill("{} {}".format(request.method, request.url),
                         width=79,
-                        subsequent_indent=' ' * (len(request.method)+1))
+                        subsequent_indent=' ' * (len(request.method) + 1))
     req_headers = [
         textwrap.fill("{}: {}".format(*sanitize(header)),
                       width=79,
-                      subsequent_indent=' '*4)
+                      subsequent_indent=' ' * 4)
         for header in request.headers.items()
     ]
     req_body = (textwrap.fill(to_unicode(request.body), width=79)
@@ -83,10 +83,10 @@ def response_to_string(response):
                                         response.reason
                                         if response.reason else ""),
                          width=79,
-                         subsequent_indent=' ' * (len(request.method)+1))
+                         subsequent_indent=' ' * (len(request.method) + 1))
     resp_headers = [
         textwrap.fill("{}: {}".format(*header), width=79,
-                      subsequent_indent=' '*4)
+                      subsequent_indent=' ' * 4)
         for header in response.headers.items()
     ]
     resp_body = textwrap.fill(response.text, width=79) if response.text else ""

--- a/ciscosparkapi/responsecodes.py
+++ b/ciscosparkapi/responsecodes.py
@@ -24,6 +24,8 @@ SPARK_RESPONSE_CODES = {
     404: "The URI requested is invalid or the resource requested, such as a "
          "user, does not exist. Also returned when the requested format is "
          "not supported by the requested method.",
+    405: "The request was made to a resource using an HTTP request method "
+         "that is not supported.",
     409: "The request could not be processed because it conflicts with some "
          "established rule of the system. For example, a person may not be "
          "added to a room more than once.",
@@ -32,6 +34,8 @@ SPARK_RESPONSE_CODES = {
          "present that specifies how many seconds you need to wait before a "
          "successful request can be made.",
     500: "Something went wrong on the server.",
+    503: "The server received an invalid response from an upstream server "
+         "while processing the request. Try again later.",
     503: "Server is overloaded with requests. Try again later."
 }
 

--- a/ciscosparkapi/responsecodes.py
+++ b/ciscosparkapi/responsecodes.py
@@ -34,7 +34,7 @@ SPARK_RESPONSE_CODES = {
          "present that specifies how many seconds you need to wait before a "
          "successful request can be made.",
     500: "Something went wrong on the server.",
-    503: "The server received an invalid response from an upstream server "
+    502: "The server received an invalid response from an upstream server "
          "while processing the request. Try again later.",
     503: "Server is overloaded with requests. Try again later."
 }

--- a/ciscosparkapi/sparkdata.py
+++ b/ciscosparkapi/sparkdata.py
@@ -2,8 +2,8 @@
 """SparkData base-class; models Spark JSON objects as native Python objects.
 
 The SparkData class models any JSON object passed to it as a string or Python
-dictionary as a native Python object; providing attribute access access using
-native object.attribute syntax.
+dictionary as a native Python object; providing attribute access using native
+dot-syntax (`object.attribute`).
 
 SparkData is intended to serve as a base-class, which provides inheritable
 functionality, for concrete sub-classes that model specific Cisco Spark data
@@ -14,11 +14,11 @@ provides a measure of future-proofing when additional data attributes are added
 to objects by the Cisco Spark cloud.
 
 Example:
-    >>> json_obj = '{"created": "2012-06-15T20:36:48.914Z",
-                     "displayName": "Chris Lunsford (chrlunsf)",
-                     "id": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS9mZjhlZTZmYi1hZm...",
-                     "avatar": "https://1efa7a94ed216783e352-c622665287144...",
-                     "emails": ["chrlunsf@cisco.com"]}'
+    >>> json_obj = '''{"created": "2012-06-15T20:36:48.914Z",
+                       "displayName": "Chris Lunsford (chrlunsf)",
+                       "id": "Y2lzY29zcGFyazovL3VzL1BFT1BMRS9mZjhlZTZmYi1h...",
+                       "avatar": "https://1efa7a94ed216783e352-c6226652871...",
+                       "emails": ["chrlunsf@cisco.com"]}'''
     >>> python_obj = SparkData(json_obj)
     >>> python_obj.displayName
     u'Chris Lunsford (chrlunsf)'
@@ -48,7 +48,7 @@ __license__ = "MIT"
 
 
 def _json_dict(json):
-    """Given a JSON dictionary or string; return a dictionary.
+    """Given a dictionary or JSON string; return a dictionary.
 
     Args:
         json(dict, str): Input JSON object.
@@ -74,7 +74,7 @@ class SparkData(object):
     """Model Spark JSON objects as native Python objects."""
 
     def __init__(self, json):
-        """Init a new SparkData object from a JSON dictionary or string.
+        """Init a new SparkData object from a dictionary or JSON string.
 
         Args:
             json(dict, str): Input JSON object.
@@ -87,7 +87,7 @@ class SparkData(object):
         self._json = _json_dict(json)
 
     def __getattr__(self, item):
-        """Provide native attribute access to the JSON object's attributes.
+        """Provide native attribute access to the JSON object attributes.
 
         This method is called when attempting to access a object attribute that
         hasn't been defined for the object.  For example trying to access

--- a/ciscosparkapi/utils.py
+++ b/ciscosparkapi/utils.py
@@ -151,9 +151,10 @@ def dict_from_items_with_values(*dictionaries, **items):
         dict: A dictionary containing all of the items with a 'non-None' value.
 
     """
-    dictionaries.append(items)
+    dict_list = list(dictionaries)
+    dict_list.append(items)
     result = {}
-    for d in dictionaries:
+    for d in dict_list:
         for key, value in d.items():
             if value is not None:
                 result[key] = value

--- a/ciscosparkapi/utils.py
+++ b/ciscosparkapi/utils.py
@@ -75,6 +75,60 @@ def open_local_file(file_path):
                          content_type=content_type)
 
 
+def check_type(o, acceptable_types, may_be_none=True):
+    """Object is an instance of one of the acceptable types or None.
+
+    Args:
+        o: The object to be inspected.
+        acceptable_types: A type or tuple of acceptable types.
+        may_be_none(bool): Whether or not the object may be None.
+
+    Raises:
+        TypeError: If the object is None and may_be_none=False, or if the
+            object is not an instance of one of the acceptable types.
+
+    """
+    if may_be_none and o is None:
+        # Object is None, and that is OK!
+        pass
+    elif isinstance(o, acceptable_types):
+        # Object is an instance of an acceptable type.
+        pass
+    else:
+        # Object is something else.
+        error_message = (
+            "We were expecting to receive an instance of one of the following "
+            "types: {types}{none}; but instead we received {o} which is a "
+            "{o_type}.".format(
+                types=", ".join([repr(t.__name__) for t in acceptable_types]),
+                none="or 'None'" if may_be_none else "",
+                o=o,
+                o_type=repr(type(o).__name__)
+            )
+        )
+        raise TypeError(error_message)
+
+
+def dict_from_items_with_values(*dictionaries, **items):
+    """Creates a dict with the inputted items; pruning any that are `None`.
+
+    Args:
+        *dictionaries(dict): Dictionaries of items to be pruned and included.
+        **items: Items to be pruned and included.
+
+    Returns:
+        dict: A dictionary containing all of the items with a 'non-None' value.
+
+    """
+    dictionaries.append(items)
+    result = {}
+    for d in dictionaries:
+        for key, value in d.items():
+            if value is not None:
+                result[key] = value
+    return result
+
+
 def raise_if_extra_kwargs(kwargs):
     """Raise a TypeError if kwargs is not empty."""
     if kwargs:

--- a/docs/user/api.rst
+++ b/docs/user/api.rst
@@ -117,6 +117,8 @@ Exceptions
 
 .. autoexception:: SparkApiError
 
+.. autoexception:: SparkRateLimitError
+
 
 .. _Spark Data Objects:
 
@@ -178,6 +180,14 @@ Webhook
 -------
 
 .. autoclass:: Webhook()
+
+
+.. _WebhookEvent:
+
+Webhook Event
+-------------
+
+.. autoclass:: WebhookEvent()
 
 
 .. _Organization:

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -303,10 +303,9 @@ You can catch any errors returned by the Cisco Spark cloud by catching
     >>>
 
 ciscosparkapi will also raise a number of other standard errors
-(:exc:`AssertionError`, :exc:`TypeError`, etc.) and other package errors like
-:exc:`ciscosparkapiException`; however, these errors are usually caused by
-incorrect use of the package or methods and should be sorted while debugging
-your app.
+(:exc:`TypeError`, :exc:`ValueError`, etc.); however, these errors are usually
+caused by incorrect use of the package or methods and should be sorted while
+debugging your app.
 
 
 Working with Returned Objects

--- a/tests/api/test_messages.py
+++ b/tests/api/test_messages.py
@@ -207,7 +207,7 @@ class TestMessagesAPI(object):
 
     def test_list_messages_mentioning_me(self, api, group_room,
                                          group_room_markdown_message):
-        messages = list_messages(api, group_room.id, mentionedPeople=["me"])
+        messages = list_messages(api, group_room.id, mentionedPeople="me")
         messages_list = list(messages)
         assert len(messages_list) >= 1
         assert are_valid_messages(messages_list)

--- a/tests/api/test_people.py
+++ b/tests/api/test_people.py
@@ -180,6 +180,12 @@ class TestPeopleAPI(object):
         assert len(list_of_people) >= 1
         assert are_valid_people(list_of_people)
 
+    def test_list_people_by_id(self, api, test_people):
+        id = test_people["not_a_member"].id
+        list_of_people = list_people(api, id=id)
+        assert len(list_of_people) >= 1
+        assert are_valid_people(list_of_people)
+
     def test_list_people_with_paging(self, api, test_people,
                                      additional_group_room_memberships):
         page_size = 1


### PR DESCRIPTION
Resolving issue #44 (and then some...)

All of the API wrappers and data models have been reviewed and updated to match the latest Cisco Spark API capabilities.  **-and-**  We have completed a significant internal restructuring to improve all of the API wrappers:

* All API methods that accept parameters and post-data have been updated to consistently accept optional (`**request_parameters`) keyword arguments.  So, **if Cisco releases an API update tomorrow with some new awesome parameter...  You can go ahead and use it.**  We'll update the code later so that it shows up in your IDE as soon as we can.

* **New WebhookEvent** - Webhook posts to your bot or automation can now be modeled via a new `WebhookEvent`.  Just pass the JSON body that Spark posts to your web service to the `WebhookEvent()` initializer and you can use native dot-syntax to access all of the attributes.

* **Exceptions** - some changes to what exceptions are raised...
  * **TypeErrors** - If you happen to pass an incorrectly typed parameter to one of the API methods or object initializers, the package will now raise a more appropriate and informative `TypeError` rather than an `AssertionError`.
  * **ValueErrors** - If you pass an incorrect value... You guessed it `ValueError`.

Exception handling should be very straightforward now.  **The only exception that you should have to catch and handle at runtime should be the `SparkApiError`'s**, which are returned when Cisco Spark responds with an error code.  By the way, these were recently updated to show you the full request and response body, when an error occurs.  Any other errors should show up and be addressed when you are writing and debugging your code.
