### PR TITLE
Documentation - Fix warnings, add to CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ buildpackage : setup.py
 
 .PHONY : docs
 docs : docs/Makefile
-	cd docs/ && $(MAKE) html
+	cd docs/ && $(MAKE) html SPHINXOPTS="-W"
 
 
 # Local project directory and environment management recipes
@@ -38,8 +38,7 @@ ci-init :
 	pipenv install
 
 .PHONY : ci
-ci :
-	pipenv run pytest -m "not ratelimit"
+ci : pytest docs
 
 .PHONY : toxtest
 toxtest : tox.ini

--- a/ciscosparkapi/api/access_tokens.py
+++ b/ciscosparkapi/api/access_tokens.py
@@ -96,7 +96,7 @@ class AccessTokensAPI(object):
 
         Returns:
             ciscosparkapi.AccessToken: An AccessToken object with the access
-                token provided by the Cisco Spark cloud.
+            token provided by the Cisco Spark cloud.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -137,7 +137,7 @@ class AccessTokensAPI(object):
 
         Returns:
             AccessToken: With the access token provided by the Cisco Spark
-                cloud.
+            cloud.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/events.py
+++ b/ciscosparkapi/api/events.py
@@ -96,7 +96,7 @@ class EventsAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the events returned by the Cisco Spark query.
+            yields the events returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/licenses.py
+++ b/ciscosparkapi/api/licenses.py
@@ -83,7 +83,7 @@ class LicensesAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the licenses returned by the Cisco Spark query.
+            yields the licenses returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -114,7 +114,7 @@ class LicensesAPI(object):
 
         Returns:
             License: A License object with the details of the requested
-                License.
+            License.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/memberships.py
+++ b/ciscosparkapi/api/memberships.py
@@ -93,7 +93,7 @@ class MembershipsAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the memberships returned by the Cisco Spark query.
+            yields the memberships returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -137,7 +137,7 @@ class MembershipsAPI(object):
 
         Returns:
             Membership: A Membership object with the details of the created
-                membership.
+            membership.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -171,7 +171,7 @@ class MembershipsAPI(object):
 
         Returns:
             Membership: A Membership object with the details of the requested
-                membership.
+            membership.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -197,7 +197,7 @@ class MembershipsAPI(object):
 
         Returns:
             Membership: A Membership object with the updated Spark membership
-                details.
+            details.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/messages.py
+++ b/ciscosparkapi/api/messages.py
@@ -137,7 +137,7 @@ class MessagesAPI(object):
                 specified this parameter may be optionally used to provide
                 alternate text for UI clients that do not support rich text.
             markdown(basestring): The message, in markdown format.
-            files(list): A list of public URL(s) or local path(s) to files to
+            files(`list`): A list of public URL(s) or local path(s) to files to
                 be posted into the room. Only one file is allowed per message.
                 Uploaded files are automatically converted into a format that
                 all Spark clients can render.

--- a/ciscosparkapi/api/messages.py
+++ b/ciscosparkapi/api/messages.py
@@ -90,7 +90,7 @@ class MessagesAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the messages returned by the Cisco Spark query.
+            yields the messages returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -213,7 +213,7 @@ class MessagesAPI(object):
 
         Returns:
             Message: A Message object with the details of the requested
-                message.
+            message.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/organizations.py
+++ b/ciscosparkapi/api/organizations.py
@@ -79,7 +79,7 @@ class OrganizationsAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the organizations returned by the Cisco Spark query.
+            yields the organizations returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -108,7 +108,7 @@ class OrganizationsAPI(object):
 
         Returns:
             Organization: An Organization object with the details of the
-                requested organization.
+            requested organization.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -86,7 +86,7 @@ class PeopleAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the people returned by the Cisco Spark query.
+            yields the people returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/people.py
+++ b/ciscosparkapi/api/people.py
@@ -123,16 +123,16 @@ class PeopleAPI(object):
         Only an admin can create a new user account.
 
         Args:
-            emails(list): Email address(es) of the person (list of strings).
+            emails(`list`): Email address(es) of the person (list of strings).
             displayName(basestring): Full name of the person.
             firstName(basestring): First name of the person.
             lastName(basestring): Last name of the person.
             avatar(basestring): URL to the person's avatar in PNG format.
             orgId(basestring): ID of the organization to which this
                 person belongs.
-            roles(list): Roles of the person (list of strings containing
+            roles(`list`): Roles of the person (list of strings containing
                 the role IDs to be assigned to the person).
-            licenses(list): Licenses allocated to the person (list of
+            licenses(`list`): Licenses allocated to the person (list of
                 strings - containing the license IDs to be allocated to the
                 person).
             **request_parameters: Additional request parameters (provides
@@ -211,16 +211,16 @@ class PeopleAPI(object):
 
         Args:
             personId(basestring): The person ID.
-            emails(list): Email address(es) of the person (list of strings).
+            emails(`list`): Email address(es) of the person (list of strings).
             displayName(basestring): Full name of the person.
             firstName(basestring): First name of the person.
             lastName(basestring): Last name of the person.
             avatar(basestring): URL to the person's avatar in PNG format.
             orgId(basestring): ID of the organization to which this
                 person belongs.
-            roles(list): Roles of the person (list of strings containing
+            roles(`list`): Roles of the person (list of strings containing
                 the role IDs to be assigned to the person).
-            licenses(list): Licenses allocated to the person (list of
+            licenses(`list`): Licenses allocated to the person (list of
                 strings - containing the license IDs to be allocated to the
                 person).
             **request_parameters: Additional request parameters (provides

--- a/ciscosparkapi/api/roles.py
+++ b/ciscosparkapi/api/roles.py
@@ -79,7 +79,7 @@ class RolesAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the roles returned by the Cisco Spark query.
+            yields the roles returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/rooms.py
+++ b/ciscosparkapi/api/rooms.py
@@ -90,7 +90,7 @@ class RoomsAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the rooms returned by the Cisco Spark query.
+            yields the rooms returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/team_memberships.py
+++ b/ciscosparkapi/api/team_memberships.py
@@ -80,7 +80,7 @@ class TeamMembershipsAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the team memberships returned by the Cisco Spark query.
+            yields the team memberships returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -121,7 +121,7 @@ class TeamMembershipsAPI(object):
 
         Returns:
             TeamMembership: A TeamMembership object with the details of the
-                created team membership.
+            created team membership.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -155,7 +155,7 @@ class TeamMembershipsAPI(object):
 
         Returns:
             TeamMembership: A TeamMembership object with the details of the
-                requested team membership.
+            requested team membership.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -181,7 +181,7 @@ class TeamMembershipsAPI(object):
 
         Returns:
             TeamMembership: A TeamMembership object with the updated Spark team
-                membership details.
+            membership details.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/teams.py
+++ b/ciscosparkapi/api/teams.py
@@ -79,7 +79,7 @@ class TeamsAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the teams returned by the Cisco Spark query.
+            yields the teams returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/ciscosparkapi/api/webhooks.py
+++ b/ciscosparkapi/api/webhooks.py
@@ -79,7 +79,7 @@ class WebhooksAPI(object):
 
         Returns:
             GeneratorContainer: A GeneratorContainer which, when iterated,
-                yields the webhooks returned by the Cisco Spark query.
+            yields the webhooks returned by the Cisco Spark query.
 
         Raises:
             TypeError: If the parameter types are incorrect.
@@ -154,7 +154,7 @@ class WebhooksAPI(object):
 
         Returns:
             Webhook: A Webhook object with the details of the requested
-                webhook.
+            webhook.
 
         Raises:
             TypeError: If the parameter types are incorrect.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -62,7 +62,9 @@ if not on_rtd:
 # further.  For a list of options available for each theme, see the
 # documentation.
 #
-# html_theme_options = {}
+html_theme_options = {
+    'collapse_navigation': False
+}
 
 # Add any paths that contain custom themes here, relative to this directory.
 # html_theme_path = []
@@ -90,7 +92,7 @@ if not on_rtd:
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -54,7 +54,7 @@ What is Cisco Spark?
 --------------------
 
     "Cisco Spark is where all your work lives.  Bring your teams together in a
-     place that makes it easy to keep people and work connected."
+    place that makes it easy to keep people and work connected."
 
 Check out the official `Cisco Spark`_ website for more information and to
 create a free account!

--- a/docs/user/api.rst
+++ b/docs/user/api.rst
@@ -104,7 +104,7 @@ roles
 .. _events:
 
 events
------
+------
 
 .. autoclass:: ciscosparkapi.api.events.EventsAPI()
 

--- a/docs/user/intro.rst
+++ b/docs/user/intro.rst
@@ -136,7 +136,7 @@ Head over to the :ref:`Quickstart` page to begin working with the
 **Cisco Spark APIs in native Python**!
 
 
-.. _License:
+.. _MITLicense:
 
 MIT License
 -----------


### PR DESCRIPTION
This PR closes #58 by:

* Adding navigation to all pages (the little [+] boxes will show everywhere now)
* Fixing the outstanding warnings (this also keeps the `list` arguments for certain functions from becoming links to other methods in the documentation)
* Cleaning up the formatting of `Returns:` entries
* Adding a build of the documentation to the CI pipeline. Unfortunately (maybe fortunately), ReadTheDocs doesn't have an option to cause the build to fail when there are warnings in the documentation. Having the Travis-ci tests fail when warnings are introduced will hold the documentation to a great quality standard.